### PR TITLE
チームメンバーの複数登録

### DIFF
--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -140,6 +140,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   const [distributionEventId, setDistributionEventId] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [autoAssignLoading, setAutoAssignLoading] = useState(false);
   const [selectedForm, setSelectedForm] = useState<string>('');
   const [selectedFormTitle, setSelectedFormTitle] = useState<string>('');
   const [currentForm, setCurrentForm] = useState<CurrentForm | null>(null);
@@ -846,6 +847,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     }
 
     try {
+      setAutoAssignLoading(true);
       if (!user) {
         setError('認証が必要です');
         return;
@@ -889,6 +891,8 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     } catch (err) {
       setError('自動割り当てに失敗しました');
       console.error(err);
+    } finally {
+      setAutoAssignLoading(false);
     }
   };
 
@@ -929,15 +933,19 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     }
   };
 
-  const clearAutoAssignments = async () => {
+  const clearAutoAssignments = async (options?: { skipConfirm?: boolean; refresh?: boolean }) => {
     const year = resolvedParams?.year;
-    if (!year) return;
-    if (!selectedForm || !user) return;
-    if (!confirm('自動割り当て分だけをクリアしますか？手動割り当ては残ります。')) {
-      return;
+    if (!year) return false;
+    if (!selectedForm || !user) return false;
+    if (
+      !options?.skipConfirm &&
+      !confirm('自動割り当て分だけをクリアしますか？手動割り当ては残ります。')
+    ) {
+      return false;
     }
 
     try {
+      setAutoAssignLoading(true);
       const token = await user.getIdToken();
       const res = await fetch('/api/admin/assignments', {
         method: 'DELETE',
@@ -953,19 +961,39 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
       });
 
       if (res.ok) {
-        await loadAssignments();
-        await loadTeams();
+        if (options?.refresh !== false) {
+          await loadAssignments();
+          await loadTeams();
+        }
         clearDashboardCache(Number(year));
         setLastAutoAssignmentStats(null);
         setError('');
+        return true;
       } else {
         const errorData = await res.json();
         setError(errorData.error || '自動割り当てのクリアに失敗しました');
+        return false;
       }
     } catch (err) {
       setError('自動割り当てのクリアに失敗しました');
       console.error(err);
+      return false;
+    } finally {
+      setAutoAssignLoading(false);
     }
+  };
+
+  const clearAutoAssignmentsAndRun = async () => {
+    if (
+      !confirm(
+        '自動割り当て分だけをクリアしてから、未割り当てを自動割り当てしますか？手動割り当ては残ります。',
+      )
+    ) {
+      return;
+    }
+    const cleared = await clearAutoAssignments({ skipConfirm: true, refresh: false });
+    if (!cleared) return;
+    await performAutoAssignment();
   };
 
   const getAssignmentsForParticipant = (responseId: string) => {
@@ -1283,7 +1311,12 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
           <div className="mt-6 flex flex-col gap-3">
             <button
               onClick={performAutoAssignment}
-              disabled={!selectedForm || participants.length === 0 || teams.length === 0}
+              disabled={
+                autoAssignLoading ||
+                !selectedForm ||
+                participants.length === 0 ||
+                teams.length === 0
+              }
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
             >
               <svg className="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1294,31 +1327,61 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                   d="M13 10V3L4 14h7v7l9-11h-7z"
                 />
               </svg>
-              自動割り当てを実行
+              {autoAssignLoading ? '処理中...' : '未割り当てを自動割り当て'}
             </button>
 
             {assignments.length > 0 && (
               <div className="flex flex-col gap-2 sm:flex-row">
                 {hasAutoAssignments && (
-                  <button
-                    onClick={clearAutoAssignments}
-                    className="inline-flex items-center px-4 py-2 border border-amber-300 text-sm font-medium rounded-md text-amber-800 bg-white hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
-                  >
-                    <svg
-                      className="mr-2 h-4 w-4"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
+                  <>
+                    <button
+                      onClick={() => {
+                        void clearAutoAssignments();
+                      }}
+                      disabled={autoAssignLoading}
+                      className="inline-flex items-center px-4 py-2 border border-amber-300 text-sm font-medium rounded-md text-amber-800 bg-white hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M13 10V3L4 14h7v7l9-11h-7z"
-                      />
-                    </svg>
-                    自動分だけクリア
-                  </button>
+                      <svg
+                        className="mr-2 h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M13 10V3L4 14h7v7l9-11h-7z"
+                        />
+                      </svg>
+                      自動割り当てをクリア
+                    </button>
+                    <button
+                      onClick={clearAutoAssignmentsAndRun}
+                      disabled={
+                        autoAssignLoading ||
+                        !selectedForm ||
+                        participants.length === 0 ||
+                        teams.length === 0
+                      }
+                      className="inline-flex items-center px-4 py-2 border border-indigo-300 text-sm font-medium rounded-md text-indigo-800 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                    >
+                      <svg
+                        className="mr-2 h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M4 4v6h6M20 20v-6h-6M5 19a9 9 0 0 0 14-3M19 5A9 9 0 0 0 5 8"
+                        />
+                      </svg>
+                      自動割り当てをクリアして再割り当て
+                    </button>
+                  </>
                 )}
                 <button
                   onClick={clearAssignments}

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -1688,13 +1688,9 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                     キャンセル
                   </button>
                   <button
-                    disabled={
-                      manualAssignLoading ||
-                      manualAssignTeamIds.length === 0 ||
-                      !selectedParticipant
-                    }
+                    disabled={manualAssignLoading || !selectedParticipant}
                     onClick={async () => {
-                      if (!selectedParticipant || manualAssignTeamIds.length === 0) return;
+                      if (!selectedParticipant) return;
                       try {
                         setManualAssignLoading(true);
                         const token = await user!.getIdToken();

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -1640,9 +1640,19 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
 
                 <div className="space-y-4">
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                      割り当て先チーム
-                    </label>
+                    <div className="mb-2 flex items-center justify-between gap-3">
+                      <label className="block text-sm font-medium text-gray-700">
+                        割り当て先チーム
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => setManualAssignTeamIds([])}
+                        disabled={manualAssignLoading || manualAssignTeamIds.length === 0}
+                        className="text-sm font-medium text-red-600 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400"
+                      >
+                        一括解除
+                      </button>
+                    </div>
                     <div className="max-h-72 space-y-2 overflow-y-auto rounded-md border border-gray-200 p-3">
                       {teams.map((team) => (
                         <label

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -146,7 +146,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   const [responseRecords, setResponseRecords] = useState<Record<string, ResponseRecord>>({});
   const [showManualModal, setShowManualModal] = useState(false);
   const [selectedParticipant, setSelectedParticipant] = useState<Participant | null>(null);
-  const [manualAssignTeamId, setManualAssignTeamId] = useState<string>('');
+  const [manualAssignTeamIds, setManualAssignTeamIds] = useState<string[]>([]);
   const [manualAssignLoading, setManualAssignLoading] = useState<boolean>(false);
   const [showResponseEditModal, setShowResponseEditModal] = useState(false);
   const [selectedResponseId, setSelectedResponseId] = useState<string>('');
@@ -926,8 +926,12 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     }
   };
 
+  const getAssignmentsForParticipant = (responseId: string) => {
+    return assignments.filter((a) => a.responseId === responseId);
+  };
+
   const getAssignmentForParticipant = (responseId: string) => {
-    return assignments.find((a) => a.responseId === responseId);
+    return getAssignmentsForParticipant(responseId)[0];
   };
 
   const getTeamById = (teamId: string) => {
@@ -985,8 +989,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     const normalized = normalizeAvailabilitySlots(p.availableSlots);
     if (normalized.length === 0 || normalized.includes(UNAVAILABLE_SLOT_KEY)) return false;
     if (!selectedTeamFilter) return true;
-    const a = getAssignmentForParticipant(p.responseId);
-    return a?.teamId === selectedTeamFilter;
+    return getAssignmentsForParticipant(p.responseId).some((a) => a.teamId === selectedTeamFilter);
   });
   const collator = new Intl.Collator('ja');
   const sortedParticipants = [...filteredParticipants].sort((a, b) => {
@@ -1421,8 +1424,9 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                 </thead>
                 <tbody className="bg-white divide-y divide-gray-200">
                   {sortedParticipants.map((participant) => {
-                    const assignment = getAssignmentForParticipant(participant.responseId);
-                    const team = assignment ? getTeamById(assignment.teamId) : null;
+                    const participantAssignments = getAssignmentsForParticipant(
+                      participant.responseId,
+                    );
 
                     return (
                       <tr key={participant.responseId}>
@@ -1441,11 +1445,23 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                           {formatDate(participant.submittedAt)}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
-                          <AssignmentStatusSummary
-                            assignment={assignment}
-                            team={team}
-                            areaLabel={team ? getTeamAreaLabel(team) : undefined}
-                          />
+                          <div className="space-y-2">
+                            {participantAssignments.length === 0 ? (
+                              <AssignmentStatusSummary />
+                            ) : (
+                              participantAssignments.map((assignment) => {
+                                const team = getTeamById(assignment.teamId);
+                                return (
+                                  <AssignmentStatusSummary
+                                    key={`${assignment.teamId}-${assignment.timeSlot}`}
+                                    assignment={assignment}
+                                    team={team}
+                                    areaLabel={team ? getTeamAreaLabel(team) : undefined}
+                                  />
+                                );
+                              })
+                            )}
+                          </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                           <div className="flex items-center justify-end gap-3">
@@ -1458,6 +1474,11 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                             <button
                               onClick={() => {
                                 setSelectedParticipant(participant);
+                                setManualAssignTeamIds(
+                                  getAssignmentsForParticipant(participant.responseId).map(
+                                    (assignment) => assignment.teamId,
+                                  ),
+                                );
                                 setShowManualModal(true);
                               }}
                               className="text-indigo-600 hover:text-indigo-900"
@@ -1485,8 +1506,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
             </div>
             <div className="divide-y divide-gray-200">
               {unavailableParticipants.map((participant) => {
-                const assignment = getAssignmentForParticipant(participant.responseId);
-                const team = assignment ? getTeamById(assignment.teamId) : null;
+                const participantAssignments = getAssignmentsForParticipant(participant.responseId);
 
                 return (
                   <div
@@ -1501,10 +1521,22 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                       <div className="text-xs text-gray-400 mt-1">
                         {getAvailabilityLabel(participant.availableSlots)}
                       </div>
-                      {assignment && team && (
-                        <div className="mt-2 text-xs text-gray-500">
-                          <div className="mb-1">割り当て先: {team.teamName}</div>
-                          <AssignmentStatusSummary assignment={assignment} team={team} compact />
+                      {participantAssignments.length > 0 && (
+                        <div className="mt-2 space-y-2 text-xs text-gray-500">
+                          {participantAssignments.map((assignment) => {
+                            const team = getTeamById(assignment.teamId);
+                            if (!team) return null;
+                            return (
+                              <div key={`${assignment.teamId}-${assignment.timeSlot}`}>
+                                <div className="mb-1">割り当て先: {team.teamName}</div>
+                                <AssignmentStatusSummary
+                                  assignment={assignment}
+                                  team={team}
+                                  compact
+                                />
+                              </div>
+                            );
+                          })}
                         </div>
                       )}
                     </div>
@@ -1518,6 +1550,11 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                       <button
                         onClick={() => {
                           setSelectedParticipant(participant);
+                          setManualAssignTeamIds(
+                            getAssignmentsForParticipant(participant.responseId).map(
+                              (assignment) => assignment.teamId,
+                            ),
+                          );
                           setShowManualModal(true);
                         }}
                         className="text-indigo-600 hover:text-indigo-900 text-sm font-medium"
@@ -1562,6 +1599,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
             onClose={() => {
               setShowManualModal(false);
               setSelectedParticipant(null);
+              setManualAssignTeamIds([]);
             }}
             centered={false}
             panelClassName="max-w-lg"
@@ -1575,6 +1613,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                     onClick={() => {
                       setShowManualModal(false);
                       setSelectedParticipant(null);
+                      setManualAssignTeamIds([]);
                     }}
                     className="text-gray-400 hover:text-gray-600"
                   >
@@ -1604,20 +1643,36 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                     <label className="block text-sm font-medium text-gray-700 mb-2">
                       割り当て先チーム
                     </label>
-                    <select
-                      value={manualAssignTeamId}
-                      onChange={(e) => setManualAssignTeamId(e.target.value)}
-                      className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-                    >
-                      <option value="">チームを選択</option>
+                    <div className="max-h-72 space-y-2 overflow-y-auto rounded-md border border-gray-200 p-3">
                       {teams.map((team) => (
-                        <option key={team.teamId} value={team.teamId}>
-                          {team.teamName} - {getTeamAreaLabel(team)} /{' '}
-                          {formatAvailabilitySlotLabel(team.timeSlot)} (最大{team.maxMembers || 10}
-                          人)
-                        </option>
+                        <label
+                          key={team.teamId}
+                          className="flex cursor-pointer items-start gap-3 rounded-md border border-gray-200 p-3 hover:bg-gray-50"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={manualAssignTeamIds.includes(team.teamId)}
+                            onChange={(e) => {
+                              setManualAssignTeamIds((current) =>
+                                e.target.checked
+                                  ? [...current, team.teamId]
+                                  : current.filter((teamId) => teamId !== team.teamId),
+                              );
+                            }}
+                            className="mt-1 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                          />
+                          <span className="min-w-0">
+                            <span className="block text-sm font-medium text-gray-900">
+                              {team.teamName} - {getTeamAreaLabel(team)}
+                            </span>
+                            <span className="mt-1 block text-xs text-gray-500">
+                              {formatAvailabilitySlotLabel(team.timeSlot)} / 最大
+                              {team.maxMembers || 10}人
+                            </span>
+                          </span>
+                        </label>
                       ))}
-                    </select>
+                    </div>
                   </div>
                 </div>
 
@@ -1626,23 +1681,34 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                     onClick={() => {
                       setShowManualModal(false);
                       setSelectedParticipant(null);
-                      setManualAssignTeamId('');
+                      setManualAssignTeamIds([]);
                     }}
                     className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
                   >
                     キャンセル
                   </button>
                   <button
-                    disabled={manualAssignLoading || !manualAssignTeamId || !selectedParticipant}
+                    disabled={
+                      manualAssignLoading ||
+                      manualAssignTeamIds.length === 0 ||
+                      !selectedParticipant
+                    }
                     onClick={async () => {
-                      if (!selectedParticipant || !manualAssignTeamId) return;
+                      if (!selectedParticipant || manualAssignTeamIds.length === 0) return;
                       try {
                         setManualAssignLoading(true);
                         const token = await user!.getIdToken();
-                        // 時間帯の自動決定
-                        const team = teams.find((t) => t.teamId === manualAssignTeamId);
-                        const ts = resolveAssignmentSlot(team);
-                        if (!ts) {
+                        const selectedTeams = manualAssignTeamIds
+                          .map((teamId) => teams.find((t) => t.teamId === teamId))
+                          .filter((team): team is Team => Boolean(team));
+                        const assignmentTargets = selectedTeams.map((team) => ({
+                          teamId: team.teamId,
+                          timeSlot: resolveAssignmentSlot(team),
+                        }));
+                        if (
+                          assignmentTargets.length !== manualAssignTeamIds.length ||
+                          assignmentTargets.some((target) => !target.timeSlot)
+                        ) {
                           throw new Error('選択されたチームに対応する参加可能時間が見つかりません');
                         }
                         const res = await fetch('/api/admin/assignments', {
@@ -1655,8 +1721,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                             year: resolvedParams?.year,
                             formId: selectedForm,
                             responseId: selectedParticipant.responseId,
-                            teamId: manualAssignTeamId,
-                            timeSlot: ts,
+                            assignments: assignmentTargets,
                           }),
                         });
                         const data = await res.json();
@@ -1669,7 +1734,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                         }
                         setShowManualModal(false);
                         setSelectedParticipant(null);
-                        setManualAssignTeamId('');
+                        setManualAssignTeamIds([]);
                       } catch (e: unknown) {
                         const msg = e instanceof Error ? e.message : '更新に失敗しました';
                         setError(msg);

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -148,6 +148,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   const [showManualModal, setShowManualModal] = useState(false);
   const [selectedParticipant, setSelectedParticipant] = useState<Participant | null>(null);
   const [manualAssignTeamIds, setManualAssignTeamIds] = useState<string[]>([]);
+  const [manualAssignInitialTeamIds, setManualAssignInitialTeamIds] = useState<string[]>([]);
   const [manualAssignLoading, setManualAssignLoading] = useState<boolean>(false);
   const [showResponseEditModal, setShowResponseEditModal] = useState(false);
   const [selectedResponseId, setSelectedResponseId] = useState<string>('');
@@ -1607,12 +1608,12 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                             </button>
                             <button
                               onClick={() => {
+                                const assignmentTeamIds = getAssignmentsForParticipant(
+                                  participant.responseId,
+                                ).map((assignment) => assignment.teamId);
                                 setSelectedParticipant(participant);
-                                setManualAssignTeamIds(
-                                  getAssignmentsForParticipant(participant.responseId).map(
-                                    (assignment) => assignment.teamId,
-                                  ),
-                                );
+                                setManualAssignTeamIds(assignmentTeamIds);
+                                setManualAssignInitialTeamIds(assignmentTeamIds);
                                 setShowManualModal(true);
                               }}
                               className="text-indigo-600 hover:text-indigo-900"
@@ -1683,12 +1684,12 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                       </button>
                       <button
                         onClick={() => {
+                          const assignmentTeamIds = getAssignmentsForParticipant(
+                            participant.responseId,
+                          ).map((assignment) => assignment.teamId);
                           setSelectedParticipant(participant);
-                          setManualAssignTeamIds(
-                            getAssignmentsForParticipant(participant.responseId).map(
-                              (assignment) => assignment.teamId,
-                            ),
-                          );
+                          setManualAssignTeamIds(assignmentTeamIds);
+                          setManualAssignInitialTeamIds(assignmentTeamIds);
                           setShowManualModal(true);
                         }}
                         className="text-indigo-600 hover:text-indigo-900 text-sm font-medium"
@@ -1734,6 +1735,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
               setShowManualModal(false);
               setSelectedParticipant(null);
               setManualAssignTeamIds([]);
+              setManualAssignInitialTeamIds([]);
             }}
             centered={false}
             panelClassName="max-w-lg"
@@ -1748,6 +1750,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                       setShowManualModal(false);
                       setSelectedParticipant(null);
                       setManualAssignTeamIds([]);
+                      setManualAssignInitialTeamIds([]);
                     }}
                     className="text-gray-400 hover:text-gray-600"
                   >
@@ -1835,6 +1838,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                       setShowManualModal(false);
                       setSelectedParticipant(null);
                       setManualAssignTeamIds([]);
+                      setManualAssignInitialTeamIds([]);
                     }}
                     className="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
                   >
@@ -1893,10 +1897,17 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                             formId: selectedForm,
                             responseId: selectedParticipant.responseId,
                             assignments: assignmentTargets,
+                            previousTeamIds: manualAssignInitialTeamIds,
                           }),
                         });
                         const data = await res.json();
-                        if (!res.ok) throw new Error(data.error || '更新に失敗しました');
+                        if (!res.ok) {
+                          if (res.status === 409) {
+                            await loadAssignments();
+                            await loadTeams();
+                          }
+                          throw new Error(data.error || '更新に失敗しました');
+                        }
                         // 再読込
                         await loadAssignments();
                         await loadTeams();
@@ -1906,6 +1917,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                         setShowManualModal(false);
                         setSelectedParticipant(null);
                         setManualAssignTeamIds([]);
+                        setManualAssignInitialTeamIds([]);
                       } catch (e: unknown) {
                         const msg = e instanceof Error ? e.message : '更新に失敗しました';
                         setError(msg);

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -60,6 +60,7 @@ interface Team {
 }
 
 interface Assignment {
+  formId?: string;
   responseId: string;
   teamId: string;
   assignedAt: Date;
@@ -268,7 +269,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
 
       await loadTeams();
       await loadAreas();
-      await loadAssignments();
+      await loadAssignments(nextForm?.formId);
     } catch (err) {
       setError('データの取得に失敗しました');
       console.error(err);
@@ -820,12 +821,14 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     }
   };
 
-  const loadAssignments = async () => {
+  const loadAssignments = async (formId = selectedForm) => {
     if (!resolvedParams || !user) return;
 
     try {
       const token = await user.getIdToken();
-      const res = await fetch(`/api/admin/assignments?year=${resolvedParams.year}`, {
+      const searchParams = new URLSearchParams({ year: resolvedParams.year });
+      if (formId) searchParams.set('formId', formId);
+      const res = await fetch(`/api/admin/assignments?${searchParams.toString()}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
 
@@ -998,7 +1001,9 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   };
 
   const getAssignmentsForParticipant = (responseId: string) => {
-    return assignments.filter((a) => a.responseId === responseId);
+    return assignments.filter(
+      (a) => a.responseId === responseId && (!selectedForm || a.formId === selectedForm),
+    );
   };
 
   const getAssignmentForParticipant = (responseId: string) => {

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -926,6 +926,42 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     }
   };
 
+  const clearAutoAssignments = async () => {
+    const year = resolvedParams?.year;
+    if (!year) return;
+    if (!selectedForm || !user) return;
+
+    try {
+      const token = await user.getIdToken();
+      const res = await fetch('/api/admin/assignments', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          year,
+          formId: selectedForm,
+          assignedBy: 'auto',
+        }),
+      });
+
+      if (res.ok) {
+        await loadAssignments();
+        await loadTeams();
+        clearDashboardCache(Number(year));
+        setLastAutoAssignmentStats(null);
+        setError('');
+      } else {
+        const errorData = await res.json();
+        setError(errorData.error || '自動割り当てのクリアに失敗しました');
+      }
+    } catch (err) {
+      setError('自動割り当てのクリアに失敗しました');
+      console.error(err);
+    }
+  };
+
   const getAssignmentsForParticipant = (responseId: string) => {
     return assignments.filter((a) => a.responseId === responseId);
   };
@@ -1005,6 +1041,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
       timeSlot: createTeamForm.timeSlot,
       existingCodes: teams.map((team) => team.teamCode),
     }) || '配布枠選択後に自動設定';
+  const hasAutoAssignments = assignments.some((assignment) => assignment.assignedBy !== 'manual');
 
   const buildAssignmentExportRows = (): AssignmentExportRow[] => {
     const collator = new Intl.Collator('ja');
@@ -1255,20 +1292,48 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
             </button>
 
             {assignments.length > 0 && (
-              <button
-                onClick={clearAssignments}
-                className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              >
-                <svg className="mr-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-                割り当てをクリア
-              </button>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                {hasAutoAssignments && (
+                  <button
+                    onClick={clearAutoAssignments}
+                    className="inline-flex items-center px-4 py-2 border border-amber-300 text-sm font-medium rounded-md text-amber-800 bg-white hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
+                  >
+                    <svg
+                      className="mr-2 h-4 w-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M13 10V3L4 14h7v7l9-11h-7z"
+                      />
+                    </svg>
+                    自動分だけクリア
+                  </button>
+                )}
+                <button
+                  onClick={clearAssignments}
+                  className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                >
+                  <svg
+                    className="mr-2 h-4 w-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                  割り当てをクリア
+                </button>
+              </div>
             )}
             {lastAutoAssignmentStats?.carRequiredTeamsWithoutDriver ? (
               <div className="rounded-md border border-yellow-200 bg-yellow-50 p-4 text-sm text-yellow-800">

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -896,6 +896,9 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     const year = resolvedParams?.year;
     if (!year) return;
     if (!selectedForm || !user) return;
+    if (!confirm('このフォームの割り当てをすべてクリアしますか？手動割り当ても削除されます。')) {
+      return;
+    }
 
     try {
       const token = await user.getIdToken();
@@ -930,6 +933,9 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     const year = resolvedParams?.year;
     if (!year) return;
     if (!selectedForm || !user) return;
+    if (!confirm('自動割り当て分だけをクリアしますか？手動割り当ては残ります。')) {
+      return;
+    }
 
     try {
       const token = await user.getIdToken();
@@ -1711,7 +1717,16 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                       </label>
                       <button
                         type="button"
-                        onClick={() => setManualAssignTeamIds([])}
+                        onClick={() => {
+                          if (
+                            !confirm(
+                              `${selectedParticipant.name || 'この参加者'} の割り当て選択をすべて外しますか？保存するまで反映されません。`,
+                            )
+                          ) {
+                            return;
+                          }
+                          setManualAssignTeamIds([]);
+                        }}
                         disabled={manualAssignLoading || manualAssignTeamIds.length === 0}
                         className="text-sm font-medium text-red-600 hover:text-red-800 disabled:cursor-not-allowed disabled:text-gray-400"
                       >
@@ -1766,6 +1781,28 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                     disabled={manualAssignLoading || !selectedParticipant}
                     onClick={async () => {
                       if (!selectedParticipant) return;
+                      if (
+                        manualAssignTeamIds.length === 0 &&
+                        !confirm(
+                          `${selectedParticipant.name || 'この参加者'} の割り当てをすべて解除しますか？`,
+                        )
+                      ) {
+                        return;
+                      }
+                      const currentAssignmentTeamIds = getAssignmentsForParticipant(
+                        selectedParticipant.responseId,
+                      ).map((assignment) => assignment.teamId);
+                      const currentAssignmentKey = [...currentAssignmentTeamIds].sort().join('\n');
+                      const nextAssignmentKey = [...manualAssignTeamIds].sort().join('\n');
+                      if (
+                        manualAssignTeamIds.length > 0 &&
+                        currentAssignmentKey !== nextAssignmentKey &&
+                        !confirm(
+                          `${selectedParticipant.name || 'この参加者'} の割り当て先を変更しますか？`,
+                        )
+                      ) {
+                        return;
+                      }
                       try {
                         setManualAssignLoading(true);
                         const token = await user!.getIdToken();

--- a/app/api/admin/assignments/auto/route.ts
+++ b/app/api/admin/assignments/auto/route.ts
@@ -61,27 +61,15 @@ export async function POST(request: NextRequest) {
       };
     });
 
-    const manualAssignments = existingAssignments.filter(
-      (assignment) => assignment.assignedBy === 'manual',
-    );
-
     const assignmentResult = performAutoAssignment(
       participants,
       teams,
       eventSlotChoices,
-      manualAssignments,
+      existingAssignments,
     );
 
-    // 既存の自動割り当てのみを削除し、手動割り当ては保持する
+    // 既存の割り当ては自動・手動とも固定扱いにし、未割り当て分だけ追加する
     const batch = adminDb.batch();
-    existingAssignmentsSnapshot.docs.forEach((doc) => {
-      const data = doc.data();
-      if (data.assignedBy !== 'manual') {
-        batch.delete(doc.ref);
-      }
-    });
-
-    // 割り当て結果をFirestoreに保存
     const assignmentCollection = adminDb.collection('assignments');
 
     assignmentResult.assignments.forEach((assignment) => {
@@ -93,9 +81,11 @@ export async function POST(request: NextRequest) {
       });
     });
 
-    await batch.commit();
+    if (assignmentResult.assignments.length > 0) {
+      await batch.commit();
+    }
 
-    if (year) {
+    if (year && assignmentResult.assignments.length > 0) {
       FirestoreCache.invalidateYear(parseInt(year, 10));
     }
 
@@ -111,8 +101,8 @@ export async function POST(request: NextRequest) {
       );
       return normalizedSlots.length > 0;
     });
-    const manuallyAssignedParticipantIds = new Set(
-      manualAssignments
+    const existingAssignedParticipantIds = new Set(
+      existingAssignments
         .map((assignment) => assignment.responseId)
         .filter((responseId) => participantIds.has(responseId)),
     );
@@ -120,7 +110,7 @@ export async function POST(request: NextRequest) {
       assignmentResult.assignments.map((assignment) => assignment.responseId),
     );
     const totalAssignedCount = new Set([
-      ...manuallyAssignedParticipantIds,
+      ...existingAssignedParticipantIds,
       ...autoAssignedParticipantIds,
     ]).size;
 

--- a/app/api/admin/assignments/auto/route.ts
+++ b/app/api/admin/assignments/auto/route.ts
@@ -111,11 +111,18 @@ export async function POST(request: NextRequest) {
       );
       return normalizedSlots.length > 0;
     });
-    const existingManualAssignmentCount = manualAssignments.reduce(
-      (count, assignment) => count + (participantIds.has(assignment.responseId) ? 1 : 0),
-      0,
+    const manuallyAssignedParticipantIds = new Set(
+      manualAssignments
+        .map((assignment) => assignment.responseId)
+        .filter((responseId) => participantIds.has(responseId)),
     );
-    const totalAssignedCount = existingManualAssignmentCount + assignmentResult.assignments.length;
+    const autoAssignedParticipantIds = new Set(
+      assignmentResult.assignments.map((assignment) => assignment.responseId),
+    );
+    const totalAssignedCount = new Set([
+      ...manuallyAssignedParticipantIds,
+      ...autoAssignedParticipantIds,
+    ]).size;
 
     return NextResponse.json({
       message: '自動割り当てが完了しました',

--- a/app/api/admin/assignments/route.ts
+++ b/app/api/admin/assignments/route.ts
@@ -175,7 +175,7 @@ export async function POST(request: NextRequest) {
       FirestoreCache.invalidateYear(Number(year));
     }
 
-    return NextResponse.json({ success: true, assignmentIds, assignmentId: assignmentIds[0] });
+    return NextResponse.json({ success: true, assignmentIds });
   } catch (error) {
     console.error('割り当て作成エラー:', error);
     return NextResponse.json({ error: '割り当ての作成に失敗しました' }, { status: 500 });

--- a/app/api/admin/assignments/route.ts
+++ b/app/api/admin/assignments/route.ts
@@ -71,13 +71,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: parsedPayload.error }, { status: 400 });
     }
 
-    const manualAssignments = buildManualAssignmentRecords({
-      year: parsedPayload.year,
-      formId: parsedPayload.formId,
-      responseId: parsedPayload.responseId,
-      targets: parsedPayload.targets,
-      assignedAt: new Date(),
-    });
+    const manualAssignments =
+      parsedPayload.targets.length > 0
+        ? buildManualAssignmentRecords({
+            year: parsedPayload.year,
+            formId: parsedPayload.formId,
+            responseId: parsedPayload.responseId,
+            targets: parsedPayload.targets,
+            assignedAt: new Date(),
+          })
+        : [];
     if (!manualAssignments) {
       return NextResponse.json(
         { error: 'year, formId, responseId, teamId, timeSlot が必要です' },
@@ -85,7 +88,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { year, formId, responseId } = manualAssignments[0];
+    const { year, formId, responseId } = parsedPayload;
 
     // 手動保存では同一参加者の割り当て先一覧を置き換える
     const query = await adminDb

--- a/app/api/admin/assignments/route.ts
+++ b/app/api/admin/assignments/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { adminAuth, adminDb } from '@/lib/firebase-admin';
 import { hasAdminPrivileges } from '@/lib/utils/admin/auth';
 import {
-  buildManualAssignmentRecord,
+  buildManualAssignmentRecords,
   normalizeAssignmentYear,
+  preserveExistingAssignmentLabels,
 } from '@/lib/utils/assignment/assignment-api';
 import {
   normalizeAssignmentAuthHeader,
@@ -70,44 +71,60 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: parsedPayload.error }, { status: 400 });
     }
 
-    const manualAssignment = buildManualAssignmentRecord({
+    const manualAssignments = buildManualAssignmentRecords({
       year: parsedPayload.year,
       formId: parsedPayload.formId,
       responseId: parsedPayload.responseId,
-      teamId: parsedPayload.teamId,
-      timeSlot: parsedPayload.timeSlot,
+      targets: parsedPayload.targets,
       assignedAt: new Date(),
     });
-    if (!manualAssignment) {
+    if (!manualAssignments) {
       return NextResponse.json(
         { error: 'year, formId, responseId, teamId, timeSlot が必要です' },
         { status: 400 },
       );
     }
 
-    // 既存の同一参加者の割り当てを削除（同一年度・フォーム内で一意に）
+    const { year, formId, responseId } = manualAssignments[0];
+
+    // 手動保存では同一参加者の割り当て先一覧を置き換える
     const query = await adminDb
       .collection('assignments')
-      .where('year', '==', manualAssignment.year)
-      .where('formId', '==', manualAssignment.formId)
-      .where('responseId', '==', manualAssignment.responseId)
+      .where('year', '==', year)
+      .where('formId', '==', formId)
+      .where('responseId', '==', responseId)
       .get();
     const batch = adminDb.batch();
     query.docs.forEach((doc) => batch.delete(doc.ref));
 
-    // 新しい割り当てを追加
-    const docRef = adminDb.collection('assignments').doc();
-    batch.set(docRef, {
-      ...manualAssignment,
+    const assignmentIds: string[] = [];
+    const assignmentsToSave = preserveExistingAssignmentLabels(
+      manualAssignments,
+      query.docs.map((doc) => {
+        const data = doc.data();
+        return {
+          teamId: data.teamId,
+          assignedAt: data.assignedAt,
+          assignedBy: data.assignedBy,
+        };
+      }),
+    );
+
+    assignmentsToSave.forEach((assignment) => {
+      const docRef = adminDb.collection('assignments').doc();
+      assignmentIds.push(docRef.id);
+      batch.set(docRef, {
+        ...assignment,
+      });
     });
 
     await batch.commit();
 
-    if (manualAssignment.year) {
-      FirestoreCache.invalidateYear(Number(manualAssignment.year));
+    if (year) {
+      FirestoreCache.invalidateYear(Number(year));
     }
 
-    return NextResponse.json({ success: true, assignmentId: docRef.id });
+    return NextResponse.json({ success: true, assignmentIds, assignmentId: assignmentIds[0] });
   } catch (error) {
     console.error('割り当て作成エラー:', error);
     return NextResponse.json({ error: '割り当ての作成に失敗しました' }, { status: 500 });

--- a/app/api/admin/assignments/route.ts
+++ b/app/api/admin/assignments/route.ts
@@ -3,6 +3,7 @@ import { adminAuth, adminDb } from '@/lib/firebase-admin';
 import { hasAdminPrivileges } from '@/lib/utils/admin/auth';
 import {
   buildManualAssignmentRecords,
+  hasAssignmentTeamConflict,
   preserveExistingAssignmentLabels,
 } from '@/lib/utils/assignment/assignment-api';
 import {
@@ -12,6 +13,8 @@ import {
   parseAssignmentMutationPayload,
 } from '@/lib/utils/assignment/assignment-route';
 import { FirestoreCache } from '@/lib/utils/server-cache';
+
+class AssignmentConflictError extends Error {}
 
 export async function GET(request: NextRequest) {
   try {
@@ -90,61 +93,82 @@ export async function POST(request: NextRequest) {
 
     const { year, formId, responseId } = parsedPayload;
 
-    // 手動保存では同一参加者の割り当て先一覧を更新する
-    const query = await adminDb
-      .collection('assignments')
-      .where('year', '==', year)
-      .where('formId', '==', formId)
-      .where('responseId', '==', responseId)
-      .get();
-    const batch = adminDb.batch();
-    const assignmentsToSave = preserveExistingAssignmentLabels(
-      manualAssignments,
-      query.docs.map((doc) => {
-        const data = doc.data();
-        return {
-          teamId: data.teamId,
-          assignedAt: data.assignedAt,
-          assignedBy: data.assignedBy,
-        };
-      }),
-    );
-    const assignmentsByTeamId = new Map(
-      assignmentsToSave.map((assignment) => [assignment.teamId, assignment] as const),
-    );
-    const retainedTeamIds = new Set<string>();
-    const assignmentIds: string[] = [];
-    let mutationCount = 0;
+    let assignmentIds: string[] = [];
 
-    query.docs.forEach((doc) => {
-      const data = doc.data();
-      const teamId = typeof data.teamId === 'string' ? data.teamId.trim() : '';
-      const nextAssignment = teamId ? assignmentsByTeamId.get(teamId) : undefined;
+    try {
+      assignmentIds = await adminDb.runTransaction(async (transaction) => {
+        // 手動保存では同一参加者の割り当て先一覧を、競合確認と同じトランザクション内で更新する
+        const query = await transaction.get(
+          adminDb
+            .collection('assignments')
+            .where('year', '==', year)
+            .where('formId', '==', formId)
+            .where('responseId', '==', responseId),
+        );
+        if (
+          parsedPayload.previousTeamIds &&
+          hasAssignmentTeamConflict(
+            query.docs.map((doc) => doc.data().teamId),
+            parsedPayload.previousTeamIds,
+          )
+        ) {
+          throw new AssignmentConflictError();
+        }
 
-      if (!nextAssignment || retainedTeamIds.has(teamId)) {
-        batch.delete(doc.ref);
-        mutationCount++;
-        return;
-      }
+        const assignmentsToSave = preserveExistingAssignmentLabels(
+          manualAssignments,
+          query.docs.map((doc) => {
+            const data = doc.data();
+            return {
+              teamId: data.teamId,
+              assignedAt: data.assignedAt,
+              assignedBy: data.assignedBy,
+            };
+          }),
+        );
+        const assignmentsByTeamId = new Map(
+          assignmentsToSave.map((assignment) => [assignment.teamId, assignment] as const),
+        );
+        const retainedTeamIds = new Set<string>();
+        const nextAssignmentIds: string[] = [];
 
-      retainedTeamIds.add(teamId);
-      assignmentIds.push(doc.id);
-      batch.set(doc.ref, nextAssignment);
-      mutationCount++;
-    });
+        query.docs.forEach((doc) => {
+          const data = doc.data();
+          const teamId = typeof data.teamId === 'string' ? data.teamId.trim() : '';
+          const nextAssignment = teamId ? assignmentsByTeamId.get(teamId) : undefined;
 
-    assignmentsToSave.forEach((assignment) => {
-      if (retainedTeamIds.has(assignment.teamId)) return;
-      const docRef = adminDb.collection('assignments').doc();
-      assignmentIds.push(docRef.id);
-      batch.set(docRef, {
-        ...assignment,
+          if (!nextAssignment || retainedTeamIds.has(teamId)) {
+            transaction.delete(doc.ref);
+            return;
+          }
+
+          retainedTeamIds.add(teamId);
+          nextAssignmentIds.push(doc.id);
+          transaction.set(doc.ref, nextAssignment);
+        });
+
+        assignmentsToSave.forEach((assignment) => {
+          if (retainedTeamIds.has(assignment.teamId)) return;
+          const docRef = adminDb.collection('assignments').doc();
+          nextAssignmentIds.push(docRef.id);
+          transaction.set(docRef, {
+            ...assignment,
+          });
+        });
+
+        return nextAssignmentIds;
       });
-      mutationCount++;
-    });
-
-    if (mutationCount > 0) {
-      await batch.commit();
+    } catch (error) {
+      if (error instanceof AssignmentConflictError) {
+        return NextResponse.json(
+          {
+            error:
+              '割り当てが他の操作で更新されています。最新の割り当てを読み込んでから再度保存してください。',
+          },
+          { status: 409 },
+        );
+      }
+      throw error;
     }
 
     if (year) {

--- a/app/api/admin/assignments/route.ts
+++ b/app/api/admin/assignments/route.ts
@@ -3,11 +3,11 @@ import { adminAuth, adminDb } from '@/lib/firebase-admin';
 import { hasAdminPrivileges } from '@/lib/utils/admin/auth';
 import {
   buildManualAssignmentRecords,
-  normalizeAssignmentYear,
   preserveExistingAssignmentLabels,
 } from '@/lib/utils/assignment/assignment-api';
 import {
   normalizeAssignmentAuthHeader,
+  parseAssignmentDeletePayload,
   parseAssignmentListQuery,
   parseAssignmentMutationPayload,
 } from '@/lib/utils/assignment/assignment-route';
@@ -146,35 +146,42 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: '管理者権限が必要です' }, { status: 403 });
     }
 
-    const { year, formId } = await request.json();
-
-    const normalizedYear = normalizeAssignmentYear(year);
-    if (!normalizedYear) {
-      return NextResponse.json({ error: '年度が必要です' }, { status: 400 });
+    const parsedPayload = parseAssignmentDeletePayload(await request.json());
+    if ('error' in parsedPayload) {
+      return NextResponse.json({ error: parsedPayload.error }, { status: 400 });
     }
 
-    let query = adminDb.collection('assignments').where('year', '==', normalizedYear);
+    let query = adminDb.collection('assignments').where('year', '==', parsedPayload.year);
 
-    if (formId) {
-      query = query.where('formId', '==', formId);
+    if (parsedPayload.formId) {
+      query = query.where('formId', '==', parsedPayload.formId);
     }
 
     const assignmentsSnapshot = await query.get();
+    const docsToDelete =
+      parsedPayload.assignedBy === 'auto'
+        ? assignmentsSnapshot.docs.filter((doc) => doc.data().assignedBy !== 'manual')
+        : assignmentsSnapshot.docs;
 
     const batch = adminDb.batch();
-    assignmentsSnapshot.docs.forEach((doc) => {
+    docsToDelete.forEach((doc) => {
       batch.delete(doc.ref);
     });
 
-    await batch.commit();
+    if (docsToDelete.length > 0) {
+      await batch.commit();
+    }
 
-    if (normalizedYear) {
-      FirestoreCache.invalidateYear(normalizedYear);
+    if (docsToDelete.length > 0) {
+      FirestoreCache.invalidateYear(parsedPayload.year);
     }
 
     return NextResponse.json({
-      message: '割り当てが削除されました',
-      deletedCount: assignmentsSnapshot.size,
+      message:
+        parsedPayload.assignedBy === 'auto'
+          ? '自動割り当てが削除されました'
+          : '割り当てが削除されました',
+      deletedCount: docsToDelete.length,
     });
   } catch (error) {
     console.error('割り当て削除エラー:', error);

--- a/app/api/admin/assignments/route.ts
+++ b/app/api/admin/assignments/route.ts
@@ -90,7 +90,7 @@ export async function POST(request: NextRequest) {
 
     const { year, formId, responseId } = parsedPayload;
 
-    // 手動保存では同一参加者の割り当て先一覧を置き換える
+    // 手動保存では同一参加者の割り当て先一覧を更新する
     const query = await adminDb
       .collection('assignments')
       .where('year', '==', year)
@@ -98,9 +98,6 @@ export async function POST(request: NextRequest) {
       .where('responseId', '==', responseId)
       .get();
     const batch = adminDb.batch();
-    query.docs.forEach((doc) => batch.delete(doc.ref));
-
-    const assignmentIds: string[] = [];
     const assignmentsToSave = preserveExistingAssignmentLabels(
       manualAssignments,
       query.docs.map((doc) => {
@@ -112,16 +109,43 @@ export async function POST(request: NextRequest) {
         };
       }),
     );
+    const assignmentsByTeamId = new Map(
+      assignmentsToSave.map((assignment) => [assignment.teamId, assignment] as const),
+    );
+    const retainedTeamIds = new Set<string>();
+    const assignmentIds: string[] = [];
+    let mutationCount = 0;
+
+    query.docs.forEach((doc) => {
+      const data = doc.data();
+      const teamId = typeof data.teamId === 'string' ? data.teamId.trim() : '';
+      const nextAssignment = teamId ? assignmentsByTeamId.get(teamId) : undefined;
+
+      if (!nextAssignment || retainedTeamIds.has(teamId)) {
+        batch.delete(doc.ref);
+        mutationCount++;
+        return;
+      }
+
+      retainedTeamIds.add(teamId);
+      assignmentIds.push(doc.id);
+      batch.set(doc.ref, nextAssignment);
+      mutationCount++;
+    });
 
     assignmentsToSave.forEach((assignment) => {
+      if (retainedTeamIds.has(assignment.teamId)) return;
       const docRef = adminDb.collection('assignments').doc();
       assignmentIds.push(docRef.id);
       batch.set(docRef, {
         ...assignment,
       });
+      mutationCount++;
     });
 
-    await batch.commit();
+    if (mutationCount > 0) {
+      await batch.commit();
+    }
 
     if (year) {
       FirestoreCache.invalidateYear(Number(year));

--- a/lib/utils/assignment/assignment-api.ts
+++ b/lib/utils/assignment/assignment-api.ts
@@ -109,11 +109,20 @@ export function preserveExistingAssignmentLabels(
     assignedBy?: unknown;
   }>,
 ): AssignmentRecordForLabelMerge[] {
-  const existingByTeamId = new Map(
-    existingAssignments
-      .filter((assignment) => typeof assignment.teamId === 'string' && assignment.teamId.trim())
-      .map((assignment) => [String(assignment.teamId).trim(), assignment] as const),
-  );
+  const existingByTeamId = new Map<
+    string,
+    {
+      teamId?: unknown;
+      assignedAt?: unknown;
+      assignedBy?: unknown;
+    }
+  >();
+  existingAssignments.forEach((assignment) => {
+    if (typeof assignment.teamId !== 'string') return;
+    const teamId = assignment.teamId.trim();
+    if (!teamId || existingByTeamId.has(teamId)) return;
+    existingByTeamId.set(teamId, assignment);
+  });
 
   return nextAssignments.map((assignment) => {
     const existing = existingByTeamId.get(assignment.teamId);

--- a/lib/utils/assignment/assignment-api.ts
+++ b/lib/utils/assignment/assignment-api.ts
@@ -51,3 +51,78 @@ export function buildManualAssignmentRecord(input: {
     assignedBy: 'manual',
   };
 }
+
+export function buildManualAssignmentRecords(input: {
+  year: unknown;
+  formId: unknown;
+  responseId: unknown;
+  targets: Array<{ teamId: unknown; timeSlot?: unknown }>;
+  assignedAt?: Date;
+}): Array<{
+  year: number;
+  formId: string;
+  responseId: string;
+  teamId: string;
+  timeSlot: string;
+  assignedAt: Date;
+  assignedBy: 'manual';
+}> | null {
+  if (!Array.isArray(input.targets) || input.targets.length === 0) return null;
+
+  const assignedAt = input.assignedAt || new Date();
+  const seenTeamIds = new Set<string>();
+  const records = input.targets
+    .map((target) =>
+      buildManualAssignmentRecord({
+        year: input.year,
+        formId: input.formId,
+        responseId: input.responseId,
+        teamId: target.teamId,
+        timeSlot: target.timeSlot,
+        assignedAt,
+      }),
+    )
+    .filter((record): record is NonNullable<typeof record> => {
+      if (!record || seenTeamIds.has(record.teamId)) return false;
+      seenTeamIds.add(record.teamId);
+      return true;
+    });
+
+  return records.length > 0 ? records : null;
+}
+
+type AssignmentRecordForLabelMerge = {
+  year: number;
+  formId: string;
+  responseId: string;
+  teamId: string;
+  timeSlot: string;
+  assignedAt: unknown;
+  assignedBy: 'auto' | 'manual';
+};
+
+export function preserveExistingAssignmentLabels(
+  nextAssignments: AssignmentRecordForLabelMerge[],
+  existingAssignments: Array<{
+    teamId?: unknown;
+    assignedAt?: unknown;
+    assignedBy?: unknown;
+  }>,
+): AssignmentRecordForLabelMerge[] {
+  const existingByTeamId = new Map(
+    existingAssignments
+      .filter((assignment) => typeof assignment.teamId === 'string' && assignment.teamId.trim())
+      .map((assignment) => [String(assignment.teamId).trim(), assignment] as const),
+  );
+
+  return nextAssignments.map((assignment) => {
+    const existing = existingByTeamId.get(assignment.teamId);
+    if (!existing) return assignment;
+
+    return {
+      ...assignment,
+      assignedAt: existing.assignedAt || assignment.assignedAt,
+      assignedBy: existing.assignedBy === 'auto' ? 'auto' : 'manual',
+    };
+  });
+}

--- a/lib/utils/assignment/assignment-api.ts
+++ b/lib/utils/assignment/assignment-api.ts
@@ -135,3 +135,18 @@ export function preserveExistingAssignmentLabels(
     };
   });
 }
+
+export function hasAssignmentTeamConflict(currentTeamIds: unknown[], previousTeamIds: string[]) {
+  const normalizeTeamIds = (teamIds: unknown[]) =>
+    Array.from(
+      new Set(
+        teamIds
+          .filter((teamId): teamId is string => typeof teamId === 'string' && !!teamId.trim())
+          .map((teamId) => teamId.trim()),
+      ),
+    ).sort();
+
+  return (
+    normalizeTeamIds(currentTeamIds).join('\n') !== normalizeTeamIds(previousTeamIds).join('\n')
+  );
+}

--- a/lib/utils/assignment/assignment-route.ts
+++ b/lib/utils/assignment/assignment-route.ts
@@ -80,3 +80,31 @@ export function parseAssignmentMutationPayload(input: unknown):
     targets,
   };
 }
+
+export function parseAssignmentDeletePayload(input: unknown):
+  | {
+      year: number;
+      formId: string | null;
+      assignedBy: 'all' | 'auto';
+    }
+  | { error: string } {
+  if (typeof input !== 'object' || input === null) {
+    return { error: 'リクエストボディが不正です' };
+  }
+  const payload = input as Record<string, unknown>;
+  const year =
+    typeof payload.year === 'number'
+      ? payload.year
+      : typeof payload.year === 'string' && /^\d{4}$/.test(payload.year.trim())
+        ? Number(payload.year.trim())
+        : Number.NaN;
+  const formId =
+    typeof payload.formId === 'string' && payload.formId.trim() ? payload.formId.trim() : null;
+  const assignedBy = payload.assignedBy === 'auto' ? 'auto' : 'all';
+
+  if (!Number.isInteger(year) || year <= 0) {
+    return { error: '年度が必要です' };
+  }
+
+  return { year, formId, assignedBy };
+}

--- a/lib/utils/assignment/assignment-route.ts
+++ b/lib/utils/assignment/assignment-route.ts
@@ -106,8 +106,12 @@ export function parseAssignmentDeletePayload(input: unknown):
       : typeof payload.year === 'string' && /^\d{4}$/.test(payload.year.trim())
         ? Number(payload.year.trim())
         : Number.NaN;
-  const formId =
-    typeof payload.formId === 'string' && payload.formId.trim() ? payload.formId.trim() : null;
+  let formId: string | null = null;
+  if (typeof payload.formId === 'string') {
+    const trimmed = payload.formId.trim();
+    if (!trimmed) return { error: 'formId が不正です' };
+    formId = trimmed;
+  }
   const assignedBy = payload.assignedBy === 'auto' ? 'auto' : 'all';
 
   if (!Number.isInteger(year) || year <= 0) {

--- a/lib/utils/assignment/assignment-route.ts
+++ b/lib/utils/assignment/assignment-route.ts
@@ -29,6 +29,7 @@ export function parseAssignmentMutationPayload(input: unknown):
         teamId: string;
         timeSlot?: unknown;
       }>;
+      previousTeamIds: string[] | null;
     }
   | { error: string } {
   if (typeof input !== 'object' || input === null) {
@@ -45,6 +46,12 @@ export function parseAssignmentMutationPayload(input: unknown):
 
   const formId = typeof payload.formId === 'string' ? payload.formId.trim() : '';
   const responseId = typeof payload.responseId === 'string' ? payload.responseId.trim() : '';
+  const previousTeamIds = Array.isArray(payload.previousTeamIds)
+    ? payload.previousTeamIds
+        .filter((teamId): teamId is string => typeof teamId === 'string')
+        .map((teamId) => teamId.trim())
+        .filter(Boolean)
+    : null;
   const hasAssignmentList = Array.isArray(payload.assignments);
   const targets: Array<{ teamId: string; timeSlot?: unknown }> = hasAssignmentList
     ? (payload.assignments as unknown[]).reduce<Array<{ teamId: string; timeSlot?: unknown }>>(
@@ -78,6 +85,7 @@ export function parseAssignmentMutationPayload(input: unknown):
     formId,
     responseId,
     targets,
+    previousTeamIds,
   };
 }
 

--- a/lib/utils/assignment/assignment-route.ts
+++ b/lib/utils/assignment/assignment-route.ts
@@ -45,14 +45,18 @@ export function parseAssignmentMutationPayload(input: unknown):
 
   const formId = typeof payload.formId === 'string' ? payload.formId.trim() : '';
   const responseId = typeof payload.responseId === 'string' ? payload.responseId.trim() : '';
-  const targets: Array<{ teamId: string; timeSlot?: unknown }> = Array.isArray(payload.assignments)
-    ? payload.assignments.reduce<Array<{ teamId: string; timeSlot?: unknown }>>((items, item) => {
-        if (typeof item !== 'object' || item === null) return items;
-        const target = item as Record<string, unknown>;
-        const teamId = typeof target.teamId === 'string' ? target.teamId.trim() : '';
-        if (teamId) items.push({ teamId, timeSlot: target.timeSlot });
-        return items;
-      }, [])
+  const hasAssignmentList = Array.isArray(payload.assignments);
+  const targets: Array<{ teamId: string; timeSlot?: unknown }> = hasAssignmentList
+    ? (payload.assignments as unknown[]).reduce<Array<{ teamId: string; timeSlot?: unknown }>>(
+        (items, item) => {
+          if (typeof item !== 'object' || item === null) return items;
+          const target = item as Record<string, unknown>;
+          const teamId = typeof target.teamId === 'string' ? target.teamId.trim() : '';
+          if (teamId) items.push({ teamId, timeSlot: target.timeSlot });
+          return items;
+        },
+        [],
+      )
     : typeof payload.teamId === 'string' && payload.teamId.trim()
       ? [{ teamId: payload.teamId.trim(), timeSlot: payload.timeSlot }]
       : [];
@@ -61,7 +65,11 @@ export function parseAssignmentMutationPayload(input: unknown):
     return { error: '年度が必要です' };
   }
 
-  if (!formId || !responseId || targets.length === 0) {
+  if (!formId || !responseId || (!hasAssignmentList && targets.length === 0)) {
+    return { error: 'year, formId, responseId, teamId は必須です' };
+  }
+
+  if (hasAssignmentList && (payload.assignments as unknown[]).length > 0 && targets.length === 0) {
     return { error: 'year, formId, responseId, teamId は必須です' };
   }
 

--- a/lib/utils/assignment/assignment-route.ts
+++ b/lib/utils/assignment/assignment-route.ts
@@ -25,8 +25,10 @@ export function parseAssignmentMutationPayload(input: unknown):
       year: number;
       formId: string;
       responseId: string;
-      teamId: string;
-      timeSlot?: unknown;
+      targets: Array<{
+        teamId: string;
+        timeSlot?: unknown;
+      }>;
     }
   | { error: string } {
   if (typeof input !== 'object' || input === null) {
@@ -43,13 +45,23 @@ export function parseAssignmentMutationPayload(input: unknown):
 
   const formId = typeof payload.formId === 'string' ? payload.formId.trim() : '';
   const responseId = typeof payload.responseId === 'string' ? payload.responseId.trim() : '';
-  const teamId = typeof payload.teamId === 'string' ? payload.teamId.trim() : '';
+  const targets: Array<{ teamId: string; timeSlot?: unknown }> = Array.isArray(payload.assignments)
+    ? payload.assignments.reduce<Array<{ teamId: string; timeSlot?: unknown }>>((items, item) => {
+        if (typeof item !== 'object' || item === null) return items;
+        const target = item as Record<string, unknown>;
+        const teamId = typeof target.teamId === 'string' ? target.teamId.trim() : '';
+        if (teamId) items.push({ teamId, timeSlot: target.timeSlot });
+        return items;
+      }, [])
+    : typeof payload.teamId === 'string' && payload.teamId.trim()
+      ? [{ teamId: payload.teamId.trim(), timeSlot: payload.timeSlot }]
+      : [];
 
   if (!Number.isInteger(year) || year <= 0) {
     return { error: '年度が必要です' };
   }
 
-  if (!formId || !responseId || !teamId) {
+  if (!formId || !responseId || targets.length === 0) {
     return { error: 'year, formId, responseId, teamId は必須です' };
   }
 
@@ -57,7 +69,6 @@ export function parseAssignmentMutationPayload(input: unknown):
     year,
     formId,
     responseId,
-    teamId,
-    timeSlot: payload.timeSlot,
+    targets,
   };
 }

--- a/lib/utils/assignment/auto-assignment.ts
+++ b/lib/utils/assignment/auto-assignment.ts
@@ -117,14 +117,12 @@ export function performAutoAssignment(
       (teamGradeCount[team.teamId][participant.grade] || 0) + 1;
   };
 
-  existingAssignments
-    .filter((assignment) => assignment.assignedBy === 'manual')
-    .forEach((assignment) => {
-      const participant = participantById.get(assignment.responseId);
-      const team = teamById.get(assignment.teamId);
-      if (!participant || !team) return;
-      applyAssignmentState(participant, team, assignment);
-    });
+  existingAssignments.forEach((assignment) => {
+    const participant = participantById.get(assignment.responseId);
+    const team = teamById.get(assignment.teamId);
+    if (!participant || !team) return;
+    applyAssignmentState(participant, team, assignment);
+  });
 
   const sortedParticipants = [...normalizedParticipants].sort((a, b) => {
     const aIsSenior = a.grade >= 3;

--- a/tests/assignment/assignment-api.test.ts
+++ b/tests/assignment/assignment-api.test.ts
@@ -134,4 +134,33 @@ describe('assignment api utils', () => {
       ],
     );
   });
+
+  test('preserveExistingAssignmentLabels uses the first matching existing assignment', () => {
+    const firstAssignedAt = new Date('2026-01-01T00:00:00.000Z');
+    const duplicateAssignedAt = new Date('2026-01-02T00:00:00.000Z');
+    const nextAssignments = buildManualAssignmentRecords({
+      year: '2026',
+      formId: 'form-1',
+      responseId: 'response-1',
+      assignedAt: new Date('2026-02-01T00:00:00.000Z'),
+      targets: [{ teamId: 'team-1', timeSlot: '2026-06-01_am' }],
+    });
+    assert.ok(nextAssignments);
+
+    assert.deepEqual(
+      preserveExistingAssignmentLabels(nextAssignments, [
+        {
+          teamId: 'team-1',
+          assignedAt: firstAssignedAt,
+          assignedBy: 'auto',
+        },
+        {
+          teamId: 'team-1',
+          assignedAt: duplicateAssignedAt,
+          assignedBy: 'manual',
+        },
+      ]).map(({ teamId, assignedAt, assignedBy }) => ({ teamId, assignedAt, assignedBy })),
+      [{ teamId: 'team-1', assignedAt: firstAssignedAt, assignedBy: 'auto' }],
+    );
+  });
 });

--- a/tests/assignment/assignment-api.test.ts
+++ b/tests/assignment/assignment-api.test.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   buildManualAssignmentRecord,
+  buildManualAssignmentRecords,
   normalizeAssignmentYear,
+  preserveExistingAssignmentLabels,
 } from '../../lib/utils/assignment/assignment-api';
 
 describe('assignment api utils', () => {
@@ -56,6 +58,80 @@ describe('assignment api utils', () => {
         timeSlot: 'foo',
       }),
       null,
+    );
+  });
+
+  test('buildManualAssignmentRecords builds multiple unique manual assignments', () => {
+    assert.deepEqual(
+      buildManualAssignmentRecords({
+        year: '2026',
+        formId: ' form-1 ',
+        responseId: ' response-1 ',
+        assignedAt: new Date('2026-01-01T00:00:00.000Z'),
+        targets: [
+          { teamId: ' team-1 ', timeSlot: '2026-06-01_am' },
+          { teamId: ' team-1 ', timeSlot: '2026-06-01_am' },
+          { teamId: ' team-2 ', timeSlot: '2026-06-01_pm' },
+        ],
+      }),
+      [
+        {
+          year: 2026,
+          formId: 'form-1',
+          responseId: 'response-1',
+          teamId: 'team-1',
+          timeSlot: '2026-06-01_am',
+          assignedAt: new Date('2026-01-01T00:00:00.000Z'),
+          assignedBy: 'manual',
+        },
+        {
+          year: 2026,
+          formId: 'form-1',
+          responseId: 'response-1',
+          teamId: 'team-2',
+          timeSlot: '2026-06-01_pm',
+          assignedAt: new Date('2026-01-01T00:00:00.000Z'),
+          assignedBy: 'manual',
+        },
+      ],
+    );
+  });
+
+  test('preserveExistingAssignmentLabels keeps auto labels only for assignments that remain selected', () => {
+    const assignedAt = new Date('2026-01-01T00:00:00.000Z');
+    const nextAssignments = buildManualAssignmentRecords({
+      year: '2026',
+      formId: 'form-1',
+      responseId: 'response-1',
+      assignedAt: new Date('2026-02-01T00:00:00.000Z'),
+      targets: [
+        { teamId: 'team-auto', timeSlot: '2026-06-01_am' },
+        { teamId: 'team-new', timeSlot: '2026-06-01_pm' },
+      ],
+    });
+    assert.ok(nextAssignments);
+
+    assert.deepEqual(
+      preserveExistingAssignmentLabels(nextAssignments, [
+        {
+          teamId: 'team-auto',
+          assignedAt,
+          assignedBy: 'auto',
+        },
+        {
+          teamId: 'team-removed',
+          assignedAt,
+          assignedBy: 'auto',
+        },
+      ]).map(({ teamId, assignedAt, assignedBy }) => ({ teamId, assignedAt, assignedBy })),
+      [
+        { teamId: 'team-auto', assignedAt, assignedBy: 'auto' },
+        {
+          teamId: 'team-new',
+          assignedAt: new Date('2026-02-01T00:00:00.000Z'),
+          assignedBy: 'manual',
+        },
+      ],
     );
   });
 });

--- a/tests/assignment/assignment-api.test.ts
+++ b/tests/assignment/assignment-api.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import {
   buildManualAssignmentRecord,
   buildManualAssignmentRecords,
+  hasAssignmentTeamConflict,
   normalizeAssignmentYear,
   preserveExistingAssignmentLabels,
 } from '../../lib/utils/assignment/assignment-api';
@@ -162,5 +163,14 @@ describe('assignment api utils', () => {
       ]).map(({ teamId, assignedAt, assignedBy }) => ({ teamId, assignedAt, assignedBy })),
       [{ teamId: 'team-1', assignedAt: firstAssignedAt, assignedBy: 'auto' }],
     );
+  });
+
+  test('hasAssignmentTeamConflict compares normalized team id sets', () => {
+    assert.equal(
+      hasAssignmentTeamConflict([' team-2 ', 'team-1', 'team-1'], ['team-1', 'team-2']),
+      false,
+    );
+    assert.equal(hasAssignmentTeamConflict(['team-1', 'team-3'], ['team-1', 'team-2']), true);
+    assert.equal(hasAssignmentTeamConflict([], []), false);
   });
 });

--- a/tests/assignment/assignment-route.test.ts
+++ b/tests/assignment/assignment-route.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   normalizeAssignmentAuthHeader,
+  parseAssignmentDeletePayload,
   parseAssignmentListQuery,
   parseAssignmentMutationPayload,
 } from '../../lib/utils/assignment/assignment-route';
@@ -111,5 +112,40 @@ describe('assignment route utils', () => {
       'error' in invalidPrimitive ? invalidPrimitive.error : null,
       'リクエストボディが不正です',
     );
+  });
+
+  test('parseAssignmentDeletePayload supports clearing all or auto assignments only', () => {
+    assert.deepEqual(
+      parseAssignmentDeletePayload({
+        year: '2026',
+        formId: ' form-1 ',
+      }),
+      {
+        year: 2026,
+        formId: 'form-1',
+        assignedBy: 'all',
+      },
+    );
+    assert.deepEqual(
+      parseAssignmentDeletePayload({
+        year: '2026',
+        formId: ' form-1 ',
+        assignedBy: 'auto',
+      }),
+      {
+        year: 2026,
+        formId: 'form-1',
+        assignedBy: 'auto',
+      },
+    );
+
+    const invalidYear = parseAssignmentDeletePayload({
+      year: '2026.5',
+      formId: 'form-1',
+    });
+    assert.equal('error' in invalidYear ? invalidYear.error : null, '年度が必要です');
+
+    const invalidType = parseAssignmentDeletePayload(null);
+    assert.equal('error' in invalidType ? invalidType.error : null, 'リクエストボディが不正です');
   });
 });

--- a/tests/assignment/assignment-route.test.ts
+++ b/tests/assignment/assignment-route.test.ts
@@ -40,6 +40,7 @@ describe('assignment route utils', () => {
         formId: 'form-1',
         responseId: 'response-1',
         targets: [{ teamId: 'team-1', timeSlot: '2026-06-01_am' }],
+        previousTeamIds: null,
       },
     );
     assert.deepEqual(
@@ -47,6 +48,7 @@ describe('assignment route utils', () => {
         year: '2026',
         formId: ' form-1 ',
         responseId: ' response-1 ',
+        previousTeamIds: [' team-0 ', '', 123],
         assignments: [
           { teamId: ' team-1 ', timeSlot: '2026-06-01_am' },
           { teamId: ' team-2 ', timeSlot: '2026-06-01_pm' },
@@ -60,6 +62,7 @@ describe('assignment route utils', () => {
           { teamId: 'team-1', timeSlot: '2026-06-01_am' },
           { teamId: 'team-2', timeSlot: '2026-06-01_pm' },
         ],
+        previousTeamIds: ['team-0'],
       },
     );
     assert.deepEqual(
@@ -74,6 +77,7 @@ describe('assignment route utils', () => {
         formId: 'form-1',
         responseId: 'response-1',
         targets: [],
+        previousTeamIds: null,
       },
     );
     const invalidYear = parseAssignmentMutationPayload({

--- a/tests/assignment/assignment-route.test.ts
+++ b/tests/assignment/assignment-route.test.ts
@@ -38,8 +38,27 @@ describe('assignment route utils', () => {
         year: 2026,
         formId: 'form-1',
         responseId: 'response-1',
-        teamId: 'team-1',
-        timeSlot: '2026-06-01_am',
+        targets: [{ teamId: 'team-1', timeSlot: '2026-06-01_am' }],
+      },
+    );
+    assert.deepEqual(
+      parseAssignmentMutationPayload({
+        year: '2026',
+        formId: ' form-1 ',
+        responseId: ' response-1 ',
+        assignments: [
+          { teamId: ' team-1 ', timeSlot: '2026-06-01_am' },
+          { teamId: ' team-2 ', timeSlot: '2026-06-01_pm' },
+        ],
+      }),
+      {
+        year: 2026,
+        formId: 'form-1',
+        responseId: 'response-1',
+        targets: [
+          { teamId: 'team-1', timeSlot: '2026-06-01_am' },
+          { teamId: 'team-2', timeSlot: '2026-06-01_pm' },
+        ],
       },
     );
     const invalidYear = parseAssignmentMutationPayload({

--- a/tests/assignment/assignment-route.test.ts
+++ b/tests/assignment/assignment-route.test.ts
@@ -61,6 +61,20 @@ describe('assignment route utils', () => {
         ],
       },
     );
+    assert.deepEqual(
+      parseAssignmentMutationPayload({
+        year: '2026',
+        formId: ' form-1 ',
+        responseId: ' response-1 ',
+        assignments: [],
+      }),
+      {
+        year: 2026,
+        formId: 'form-1',
+        responseId: 'response-1',
+        targets: [],
+      },
+    );
     const invalidYear = parseAssignmentMutationPayload({
       year: '2026.5',
       formId: 'form-1',
@@ -76,6 +90,16 @@ describe('assignment route utils', () => {
     });
     assert.equal(
       'error' in missingField ? missingField.error : null,
+      'year, formId, responseId, teamId は必須です',
+    );
+    const invalidAssignmentList = parseAssignmentMutationPayload({
+      year: '2026',
+      formId: 'form-1',
+      responseId: 'response-1',
+      assignments: [{ teamId: ' ' }],
+    });
+    assert.equal(
+      'error' in invalidAssignmentList ? invalidAssignmentList.error : null,
       'year, formId, responseId, teamId は必須です',
     );
 

--- a/tests/assignment/auto-assignment.test.ts
+++ b/tests/assignment/auto-assignment.test.ts
@@ -137,4 +137,50 @@ describe('auto assignment utils', () => {
       false,
     );
   });
+
+  test('existing auto assignments are preserved when auto assignment runs again', () => {
+    const result = performAutoAssignment(
+      [
+        {
+          responseId: 'driver',
+          name: '既存運転者',
+          grade: 3,
+          section: 'PR',
+          availableSlots: eventSlotKeys,
+          carUsage: '運転できる',
+        },
+        {
+          responseId: 'member',
+          name: '追加メンバー',
+          grade: 2,
+          section: 'PR',
+          availableSlots: eventSlotKeys,
+          carUsage: '免許を持っていない',
+        },
+      ],
+      baseTeams,
+      eventSlotKeys,
+      [
+        {
+          responseId: 'driver',
+          teamId: 'team-car',
+          assignedAt: new Date('2026-01-01T00:00:00.000Z'),
+          assignedBy: 'auto',
+          timeSlot: '2026-06-01_am',
+        },
+      ],
+    );
+
+    assert.equal(result.carRequiredTeamIdsWithoutDriver.length, 0);
+    assert.equal(
+      result.assignments.some(
+        (assignment) => assignment.responseId === 'driver' && assignment.teamId === 'team-car',
+      ),
+      false,
+    );
+    assert.equal(
+      result.assignments.some((assignment) => assignment.responseId === 'member'),
+      true,
+    );
+  });
 });


### PR DESCRIPTION
## 📊 Pull Request 実装状況レポート
## 🟢 **実装完了**

### Issues #140 : チーム割り当てで人を複数箇所に割り当てることができるようにする

- [x] チームに複数チーム割り当てることができるようにした
- [x] チームの解除をできるようにした

---

## 🏗️ **追加実装内容**

###
 
---

## 🧪 **動作確認済み機能**

- [x] チーム割り当て解除ができるのを確認した。
- [x] チームに複数割り当てできるのを確認した

## 関連Issues
fix #140 