### PR TITLE
チーム割り当て画面の機能充実

### DIFF
--- a/app/admin/event/[year]/team/[teamId]/page.tsx
+++ b/app/admin/event/[year]/team/[teamId]/page.tsx
@@ -11,10 +11,10 @@ import {
   buildAvailabilitySlotChoices,
   formatAvailabilitySlotLabel,
 } from '@/lib/utils/availability/availability';
-import { normalizeGrade } from '@/lib/utils/grade/grade';
 import { clearDashboardCache } from '@/lib/utils/dashboard/dashboard-cache';
 import { useRequireAdmin } from '@/lib/hooks/useRequireAdmin';
 import { authenticatedFetch, fetcherAuth } from '@/lib/utils/auth-fetcher';
+import { sortByGradeThenKanaThenName } from '@/lib/utils/sort';
 
 export default function TeamDetailPage() {
   const router = useRouter();
@@ -63,6 +63,7 @@ export default function TeamDetailPage() {
     Array<{
       responseId: string;
       name: string;
+      nameKana?: string;
       grade: number;
       section: string;
       timeSlot: string;
@@ -595,36 +596,28 @@ export default function TeamDetailPage() {
                     </tr>
                   </thead>
                   <tbody className="bg-white divide-y divide-gray-200">
-                    {assignedMembers
-                      .slice()
-                      .sort((a, b) => {
-                        const aGrade = normalizeGrade(a.grade);
-                        const bGrade = normalizeGrade(b.grade);
-                        if (bGrade !== aGrade) return bGrade - aGrade;
-                        return new Intl.Collator('ja').compare(a.name || '', b.name || '');
-                      })
-                      .map((m) => (
-                        <tr key={m.responseId}>
-                          <td className="px-6 py-3 text-sm text-gray-900">{m.name}</td>
-                          <td className="px-6 py-3 text-sm text-gray-900">
-                            {m.grade ? `${m.grade}年` : '-'}
-                          </td>
-                          <td className="px-6 py-3 text-sm text-gray-900">{m.section}</td>
-                          <td className="px-6 py-3 text-sm">
-                            <span
-                              className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                                m.timeSlot.endsWith('_am')
-                                  ? 'bg-yellow-100 text-yellow-800'
-                                  : m.timeSlot.endsWith('_pm')
-                                    ? 'bg-purple-100 text-purple-800'
-                                    : 'bg-gray-100 text-gray-800'
-                              }`}
-                            >
-                              {formatAvailabilitySlotLabel(m.timeSlot)}
-                            </span>
-                          </td>
-                        </tr>
-                      ))}
+                    {sortByGradeThenKanaThenName(assignedMembers).map((m) => (
+                      <tr key={m.responseId}>
+                        <td className="px-6 py-3 text-sm text-gray-900">{m.name}</td>
+                        <td className="px-6 py-3 text-sm text-gray-900">
+                          {m.grade ? `${m.grade}年` : '-'}
+                        </td>
+                        <td className="px-6 py-3 text-sm text-gray-900">{m.section}</td>
+                        <td className="px-6 py-3 text-sm">
+                          <span
+                            className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                              m.timeSlot.endsWith('_am')
+                                ? 'bg-yellow-100 text-yellow-800'
+                                : m.timeSlot.endsWith('_pm')
+                                  ? 'bg-purple-100 text-purple-800'
+                                  : 'bg-gray-100 text-gray-800'
+                            }`}
+                          >
+                            {formatAvailabilitySlotLabel(m.timeSlot)}
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
                   </tbody>
                 </table>
               </div>

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -1049,10 +1049,22 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   }
 
   const stats = getAssignmentStats();
-  const unavailableParticipants = participants.filter((p) => {
-    const normalized = normalizeAvailabilitySlots(p.availableSlots);
-    return normalized.length === 0 || normalized.includes(UNAVAILABLE_SLOT_KEY);
-  });
+  const collator = new Intl.Collator('ja');
+  const sortParticipantsByGradeAndName = (items: Participant[]) =>
+    [...items].sort((a, b) => {
+      const aGrade = normalizeGrade(a.grade);
+      const bGrade = normalizeGrade(b.grade);
+      if (aGrade !== bGrade) return aGrade - bGrade;
+      const nameCompare = collator.compare(a.name || '', b.name || '');
+      if (nameCompare !== 0) return nameCompare;
+      return a.responseId.localeCompare(b.responseId);
+    });
+  const unavailableParticipants = sortParticipantsByGradeAndName(
+    participants.filter((p) => {
+      const normalized = normalizeAvailabilitySlots(p.availableSlots);
+      return normalized.length === 0 || normalized.includes(UNAVAILABLE_SLOT_KEY);
+    }),
+  );
   const unavailableCount = unavailableParticipants.length;
   const availableParticipants = participants.filter((p) => {
     const normalized = normalizeAvailabilitySlots(p.availableSlots);
@@ -1070,15 +1082,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     if (!selectedTeamFilter) return true;
     return getAssignmentsForParticipant(p.responseId).some((a) => a.teamId === selectedTeamFilter);
   });
-  const collator = new Intl.Collator('ja');
-  const sortedParticipants = [...filteredParticipants].sort((a, b) => {
-    const aGrade = normalizeGrade(a.grade);
-    const bGrade = normalizeGrade(b.grade);
-    if (bGrade !== aGrade) return bGrade - aGrade;
-    const an = a.name || '';
-    const bn = b.name || '';
-    return collator.compare(an, bn);
-  });
+  const sortedParticipants = sortParticipantsByGradeAndName(filteredParticipants);
   const generatedTeamCodePreview =
     buildNextTeamCode({
       timeSlot: createTeamForm.timeSlot,

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -36,6 +36,7 @@ import { useRequireAdmin } from '@/lib/hooks/useRequireAdmin';
 import { buildCsvContent, downloadCsvFile } from '@/lib/utils/export/export';
 import { buildNextTeamCode } from '@/lib/utils/team/team-code';
 import { compareJapaneseText, sortByGradeThenKanaThenName } from '@/lib/utils/sort';
+import { generateKana } from '@/lib/kanaUtils';
 
 interface Participant {
   responseId: string;
@@ -164,6 +165,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   );
   const responseEditModalTopRef = useRef<HTMLDivElement | null>(null);
   const [selectedTeamFilter, setSelectedTeamFilter] = useState<string>('');
+  const [participantSearchQuery, setParticipantSearchQuery] = useState<string>('');
   const [showCreateTeamForm, setShowCreateTeamForm] = useState(false);
   const [createTeamSubmitting, setCreateTeamSubmitting] = useState(false);
   const [showDebugInfo, setShowDebugInfo] = useState(false);
@@ -1052,13 +1054,29 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   }
 
   const stats = getAssignmentStats();
+  const normalizedParticipantSearchQuery = participantSearchQuery.trim();
+  const participantMatchesSearch = (participant: Participant) => {
+    if (!normalizedParticipantSearchQuery) return true;
+
+    const query = normalizedParticipantSearchQuery.toLowerCase();
+    const kanaQuery = generateKana(normalizedParticipantSearchQuery).toLowerCase();
+    const searchTargets = [
+      participant.name,
+      participant.nameKana,
+      generateKana(participant.name || ''),
+      generateKana(participant.nameKana || ''),
+    ].map((value) => String(value || '').toLowerCase());
+
+    return searchTargets.some((value) => value.includes(query) || value.includes(kanaQuery));
+  };
+  const baseUnavailableParticipants = participants.filter((p) => {
+    const normalized = normalizeAvailabilitySlots(p.availableSlots);
+    return normalized.length === 0 || normalized.includes(UNAVAILABLE_SLOT_KEY);
+  });
   const unavailableParticipants = sortByGradeThenKanaThenName(
-    participants.filter((p) => {
-      const normalized = normalizeAvailabilitySlots(p.availableSlots);
-      return normalized.length === 0 || normalized.includes(UNAVAILABLE_SLOT_KEY);
-    }),
+    baseUnavailableParticipants.filter(participantMatchesSearch),
   );
-  const unavailableCount = unavailableParticipants.length;
+  const unavailableCount = baseUnavailableParticipants.length;
   const availableParticipants = participants.filter((p) => {
     const normalized = normalizeAvailabilitySlots(p.availableSlots);
     return normalized.length > 0 && !normalized.includes(UNAVAILABLE_SLOT_KEY);
@@ -1072,6 +1090,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   const filteredParticipants = participants.filter((p) => {
     const normalized = normalizeAvailabilitySlots(p.availableSlots);
     if (normalized.length === 0 || normalized.includes(UNAVAILABLE_SLOT_KEY)) return false;
+    if (!participantMatchesSearch(p)) return false;
     if (!selectedTeamFilter) return true;
     return getAssignmentsForParticipant(p.responseId).some((a) => a.teamId === selectedTeamFilter);
   });
@@ -1558,6 +1577,16 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                         </option>
                       ))}
                     </select>
+                  </div>
+                  <div className="flex items-center gap-2 flex-col">
+                    <label className="text-sm text-gray-600">名前で検索</label>
+                    <input
+                      type="search"
+                      value={participantSearchQuery}
+                      onChange={(e) => setParticipantSearchQuery(e.target.value)}
+                      placeholder="氏名・ふりがな"
+                      className="block w-48 px-3 py-2 border border-gray-300 rounded-md text-sm"
+                    />
                   </div>
                 </div>
               </div>

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -1579,8 +1579,9 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                     </select>
                   </div>
                   <div className="flex items-center gap-2 flex-col">
-                    <label className="text-sm text-gray-600">名前で検索</label>
+                    <label htmlFor="participantSearch" className="text-sm text-gray-600">名前で検索</label>
                     <input
+                      id="participantSearch"
                       type="search"
                       value={participantSearchQuery}
                       onChange={(e) => setParticipantSearchQuery(e.target.value)}

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -35,10 +35,12 @@ import { clearDashboardCache } from '@/lib/utils/dashboard/dashboard-cache';
 import { useRequireAdmin } from '@/lib/hooks/useRequireAdmin';
 import { buildCsvContent, downloadCsvFile } from '@/lib/utils/export/export';
 import { buildNextTeamCode } from '@/lib/utils/team/team-code';
+import { compareJapaneseText, sortByGradeThenKanaThenName } from '@/lib/utils/sort';
 
 interface Participant {
   responseId: string;
   name: string;
+  nameKana?: string;
   grade: number;
   section: string;
   availableSlots: string[];
@@ -803,6 +805,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
             return {
               responseId: response.responseId,
               name: response.participantData?.name || '',
+              nameKana: response.participantData?.nameKana || '',
               grade: normalizeGrade(response.participantData?.grade),
               section: response.participantData?.section || '',
               availableSlots,
@@ -1049,17 +1052,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   }
 
   const stats = getAssignmentStats();
-  const collator = new Intl.Collator('ja');
-  const sortParticipantsByGradeAndName = (items: Participant[]) =>
-    [...items].sort((a, b) => {
-      const aGrade = normalizeGrade(a.grade);
-      const bGrade = normalizeGrade(b.grade);
-      if (aGrade !== bGrade) return aGrade - bGrade;
-      const nameCompare = collator.compare(a.name || '', b.name || '');
-      if (nameCompare !== 0) return nameCompare;
-      return a.responseId.localeCompare(b.responseId);
-    });
-  const unavailableParticipants = sortParticipantsByGradeAndName(
+  const unavailableParticipants = sortByGradeThenKanaThenName(
     participants.filter((p) => {
       const normalized = normalizeAvailabilitySlots(p.availableSlots);
       return normalized.length === 0 || normalized.includes(UNAVAILABLE_SLOT_KEY);
@@ -1082,7 +1075,7 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
     if (!selectedTeamFilter) return true;
     return getAssignmentsForParticipant(p.responseId).some((a) => a.teamId === selectedTeamFilter);
   });
-  const sortedParticipants = sortParticipantsByGradeAndName(filteredParticipants);
+  const sortedParticipants = sortByGradeThenKanaThenName(filteredParticipants);
   const generatedTeamCodePreview =
     buildNextTeamCode({
       timeSlot: createTeamForm.timeSlot,
@@ -1091,7 +1084,6 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
   const hasAutoAssignments = assignments.some((assignment) => assignment.assignedBy !== 'manual');
 
   const buildAssignmentExportRows = (): AssignmentExportRow[] => {
-    const collator = new Intl.Collator('ja');
     const rows = assignments
       .map((assignment) => {
         const participant = participants.find((item) => item.responseId === assignment.responseId);
@@ -1107,10 +1099,10 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
       .filter(Boolean) as AssignmentExportRow[];
 
     return rows.sort((a, b) => {
-      const teamCompare = collator.compare(a.team, b.team);
+      const teamCompare = compareJapaneseText(a.team, b.team);
       if (teamCompare !== 0) return teamCompare;
       if (b.grade !== a.grade) return b.grade - a.grade;
-      return collator.compare(a.name, b.name);
+      return compareJapaneseText(a.name, b.name);
     });
   };
 

--- a/app/admin/event/[year]/team/page.tsx
+++ b/app/admin/event/[year]/team/page.tsx
@@ -1579,7 +1579,9 @@ export default function TeamAssignmentPage({ params }: { params: Promise<{ year:
                     </select>
                   </div>
                   <div className="flex items-center gap-2 flex-col">
-                    <label htmlFor="participantSearch" className="text-sm text-gray-600">名前で検索</label>
+                    <label htmlFor="participantSearch" className="text-sm text-gray-600">
+                      名前で検索
+                    </label>
                     <input
                       id="participantSearch"
                       type="search"

--- a/app/api/admin/export/assignments/pdf/route.ts
+++ b/app/api/admin/export/assignments/pdf/route.ts
@@ -52,7 +52,12 @@ function groupRowsByTeam(
 
   for (const row of rows) {
     const team = row.team || '班未設定';
-    groups.set(team, [...(groups.get(team) || []), row]);
+    const groupRows = groups.get(team);
+    if (groupRows) {
+      groupRows.push(row);
+    } else {
+      groups.set(team, [row]);
+    }
   }
 
   return Array.from(groups.entries()).map(([team, groupRows]) => ({

--- a/app/api/admin/export/assignments/pdf/route.ts
+++ b/app/api/admin/export/assignments/pdf/route.ts
@@ -1,9 +1,6 @@
-import { readFile } from 'fs/promises';
-import path from 'path';
 import { NextRequest, NextResponse } from 'next/server';
-import fontkit from '@pdf-lib/fontkit';
-import { PDFDocument, PDFPage, PDFFont, rgb } from 'pdf-lib';
 import { adminAuth } from '@/lib/firebase-admin';
+import { buildSectionedTableReportPdf } from '@/lib/server/pdf/sectioned-table-report';
 import { hasAdminPrivileges } from '@/lib/utils/admin/auth';
 import { formatDate } from '@/lib/utils/dateUtils';
 
@@ -20,27 +17,7 @@ type AssignmentExportRow = {
   name: string;
 };
 
-type FontEntry = {
-  bytes: Uint8Array;
-};
-
-const PAGE_WIDTH = 595.28;
-const PAGE_HEIGHT = 841.89;
-const MARGIN_X = 34;
-const HEADER_Y = PAGE_HEIGHT - 28;
-const FOOTER_Y = 24;
-const CONTENT_TOP = PAGE_HEIGHT - 55;
-const CONTENT_BOTTOM = 48;
-const FONT_SIZE = 10;
-const HEADER_FONT_SIZE = 10;
-const TITLE_FONT_SIZE = 18;
-const LINE_HEIGHT = 13;
-const TABLE_HEADER_HEIGHT = 22;
-const TABLE_ROW_HEIGHT = 26;
-const SECTION_TITLE_HEIGHT = 20;
 const COL_WIDTHS = [80, 447];
-
-let fontEntryCache: Promise<FontEntry> | null = null;
 
 function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -55,179 +32,6 @@ function normalizeRows(value: unknown): AssignmentExportRow[] {
       grade: Number.isFinite(Number(source.grade)) ? Number(source.grade) : 0,
       name: normalizeString(source.name),
     };
-  });
-}
-
-async function loadFontEntry(): Promise<FontEntry> {
-  if (!fontEntryCache) {
-    fontEntryCache = (async () => {
-      try {
-        const fontPath = path.join(
-          process.cwd(),
-          'node_modules',
-          '@expo-google-fonts',
-          'noto-sans-jp',
-          '400Regular',
-          'NotoSansJP_400Regular.ttf',
-        );
-        return {
-          bytes: await readFile(fontPath),
-        };
-      } catch (error) {
-        fontEntryCache = null;
-        throw error;
-      }
-    })();
-  }
-
-  return fontEntryCache;
-}
-
-function splitTextToLines(input: {
-  font: PDFFont;
-  text: string;
-  maxWidth: number;
-  size: number;
-  maxLines: number;
-}): string[] {
-  const lines: string[] = [];
-  let current = '';
-  let currentWidth = 0;
-  const chars = Array.from(input.text || '-');
-
-  for (const char of chars) {
-    const width = input.font.widthOfTextAtSize(char, input.size);
-    if (current && currentWidth + width > input.maxWidth) {
-      lines.push(current);
-      current = char;
-      currentWidth = width;
-      if (lines.length >= input.maxLines) break;
-    } else {
-      current += char;
-      currentWidth += width;
-    }
-  }
-
-  if (lines.length < input.maxLines && current) {
-    lines.push(current);
-  }
-
-  if (lines.length > 0 && chars.join('').length > lines.join('').length) {
-    lines[lines.length - 1] = `${lines[lines.length - 1].slice(0, -1)}…`;
-  }
-
-  return lines.length > 0 ? lines : ['-'];
-}
-
-function drawText(input: {
-  page: PDFPage;
-  font: PDFFont;
-  text: string;
-  x: number;
-  y: number;
-  size: number;
-  color?: ReturnType<typeof rgb>;
-}) {
-  input.page.drawText(input.text, {
-    x: input.x,
-    y: input.y,
-    size: input.size,
-    font: input.font,
-    color: input.color || rgb(0.07, 0.09, 0.15),
-  });
-}
-
-function drawRect(
-  page: PDFPage,
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  fill: boolean,
-) {
-  page.drawRectangle({
-    x,
-    y,
-    width,
-    height,
-    borderWidth: 0.5,
-    borderColor: rgb(0.82, 0.84, 0.88),
-    color: fill ? rgb(0.95, 0.96, 0.98) : undefined,
-  });
-}
-
-function drawWrappedCell(input: {
-  page: PDFPage;
-  font: PDFFont;
-  text: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  size?: number;
-  maxLines?: number;
-  fill?: boolean;
-}) {
-  drawRect(input.page, input.x, input.y, input.width, input.height, Boolean(input.fill));
-  const size = input.size || FONT_SIZE;
-  const lines = splitTextToLines({
-    font: input.font,
-    text: input.text,
-    maxWidth: input.width - 10,
-    size,
-    maxLines: input.maxLines || 2,
-  });
-  const totalTextHeight = lines.length * LINE_HEIGHT;
-  let textY = input.y + (input.height - totalTextHeight) / 2 + (LINE_HEIGHT - size) / 2;
-  textY += (lines.length - 1) * LINE_HEIGHT;
-
-  for (const line of lines) {
-    drawText({
-      page: input.page,
-      font: input.font,
-      text: line,
-      x: input.x + 5,
-      y: textY,
-      size,
-    });
-    textY -= LINE_HEIGHT;
-  }
-}
-
-function drawHeaderFooter(input: {
-  page: PDFPage;
-  font: PDFFont;
-  header: string;
-  pageNumber: number;
-  pageCount: number;
-}) {
-  drawText({
-    page: input.page,
-    font: input.font,
-    text: input.header,
-    x: MARGIN_X,
-    y: HEADER_Y,
-    size: HEADER_FONT_SIZE,
-    color: rgb(0.22, 0.26, 0.32),
-  });
-  drawText({
-    page: input.page,
-    font: input.font,
-    text: 'PR系',
-    x: MARGIN_X,
-    y: FOOTER_Y,
-    size: HEADER_FONT_SIZE,
-    color: rgb(0.22, 0.26, 0.32),
-  });
-  const pageNumberText = `[${input.pageNumber}/${input.pageCount}]`;
-  drawText({
-    page: input.page,
-    font: input.font,
-    text: pageNumberText,
-    x: PAGE_WIDTH - MARGIN_X - input.font.widthOfTextAtSize(pageNumberText, HEADER_FONT_SIZE),
-    y: FOOTER_Y,
-    size: HEADER_FONT_SIZE,
-    color: rgb(0.22, 0.26, 0.32),
   });
 }
 
@@ -258,150 +62,32 @@ function groupRowsByTeam(
 }
 
 async function buildPdf(input: { year: string; rows: AssignmentExportRow[] }) {
-  const pdfDoc = await PDFDocument.create();
-  pdfDoc.registerFontkit(fontkit);
-  const fontEntry = await loadFontEntry();
-  const font = await pdfDoc.embedFont(fontEntry.bytes, { subset: false });
   const groups = groupRowsByTeam(sortRows(input.rows));
-  const header = `工大祭実行委員会-学外配布${input.year}`;
-  const pageChunks: Array<
-    Array<
-      { type: 'section'; team: string; count: number } | { type: 'row'; row: AssignmentExportRow }
-    >
-  > = [];
-  let current: Array<
-    { type: 'section'; team: string; count: number } | { type: 'row'; row: AssignmentExportRow }
-  > = [];
-  let usedHeight = 86;
-  const usableHeight = CONTENT_TOP - CONTENT_BOTTOM;
-
-  const pushPage = () => {
-    pageChunks.push(current);
-    current = [];
-    usedHeight = 0;
-  };
-
-  for (const group of groups) {
-    const sectionHeight = SECTION_TITLE_HEIGHT + TABLE_HEADER_HEIGHT;
-    if (current.length > 0 && usedHeight + sectionHeight + TABLE_ROW_HEIGHT > usableHeight) {
-      pushPage();
-    }
-
-    current.push({ type: 'section', team: group.team, count: group.rows.length });
-    usedHeight += sectionHeight;
-
-    for (const row of group.rows) {
-      if (usedHeight + TABLE_ROW_HEIGHT > usableHeight) {
-        pushPage();
-        current.push({
-          type: 'section',
-          team: `${group.team}（続き）`,
-          count: group.rows.length,
-        });
-        usedHeight += sectionHeight;
-      }
-
-      current.push({ type: 'row', row });
-      usedHeight += TABLE_ROW_HEIGHT;
-    }
-  }
-
-  if (current.length === 0) {
-    current.push({ type: 'section', team: '割り当てなし', count: 0 });
-  }
-  pageChunks.push(current);
-
-  for (const [pageIndex, items] of pageChunks.entries()) {
-    const page = pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
-    drawHeaderFooter({
-      page,
-      font,
-      header,
-      pageNumber: pageIndex + 1,
-      pageCount: pageChunks.length,
-    });
-
-    let y = CONTENT_TOP;
-    if (pageIndex === 0) {
-      drawText({
-        page,
-        font,
-        text: 'チーム割り当て一覧',
-        x: MARGIN_X,
-        y,
-        size: TITLE_FONT_SIZE,
-      });
-      y -= 28;
-      drawText({
-        page,
-        font,
-        text: `年度: ${input.year}　割り当て数: ${input.rows.length}名　出力日時: ${formatDate(new Date())}`,
-        x: MARGIN_X,
-        y,
-        size: HEADER_FONT_SIZE,
-        color: rgb(0.29, 0.33, 0.39),
-      });
-      page.drawLine({
-        start: { x: MARGIN_X, y: y - 14 },
-        end: { x: PAGE_WIDTH - MARGIN_X, y: y - 14 },
-        thickness: 0.5,
-        color: rgb(0.82, 0.84, 0.88),
-      });
-      y -= 40;
-    }
-
-    for (const row of items) {
-      if (row.type === 'section') {
-        drawText({
-          page,
-          font,
-          text: `${row.team} ${row.count}名`,
-          x: MARGIN_X,
-          y: y - 14,
-          size: 12,
-        });
-        y -= SECTION_TITLE_HEIGHT;
-
-        let headerX = MARGIN_X;
-        for (const [index, title] of ['学年', '氏名'].entries()) {
-          drawWrappedCell({
-            page,
-            font,
-            text: title,
-            x: headerX,
-            y: y - TABLE_HEADER_HEIGHT,
-            width: COL_WIDTHS[index],
-            height: TABLE_HEADER_HEIGHT,
-            size: FONT_SIZE,
-            maxLines: 1,
-            fill: true,
-          });
-          headerX += COL_WIDTHS[index];
-        }
-        y -= TABLE_HEADER_HEIGHT;
-        continue;
-      }
-
-      const values = [row.row.grade > 0 ? `${row.row.grade}年` : '-', row.row.name || '-'];
-      let x = MARGIN_X;
-      for (const [index, value] of values.entries()) {
-        drawWrappedCell({
-          page,
-          font,
-          text: value,
-          x,
-          y: y - TABLE_ROW_HEIGHT,
-          width: COL_WIDTHS[index],
-          height: TABLE_ROW_HEIGHT,
-          maxLines: index === 1 ? 2 : 1,
-        });
-        x += COL_WIDTHS[index];
-      }
-      y -= TABLE_ROW_HEIGHT;
-    }
-  }
-
-  return pdfDoc.save();
+  return buildSectionedTableReportPdf({
+    title: 'チーム割り当て一覧',
+    metaText: `年度: ${input.year}　割り当て数: ${input.rows.length}名　出力日時: ${formatDate(new Date())}`,
+    header: `工大祭実行委員会-学外配布${input.year}`,
+    sections: groups.map((group) => ({
+      label: group.team,
+      count: group.rows.length,
+      rows: group.rows,
+    })),
+    emptySectionLabel: '割り当てなし',
+    columns: [
+      {
+        title: '学年',
+        width: COL_WIDTHS[0],
+        getText: (row) => (row.grade > 0 ? `${row.grade}年` : '-'),
+        maxLines: 1,
+      },
+      {
+        title: '氏名',
+        width: COL_WIDTHS[1],
+        getText: (row) => row.name || '-',
+        maxLines: 2,
+      },
+    ],
+  });
 }
 
 export async function POST(request: NextRequest) {

--- a/app/api/admin/export/assignments/pdf/route.ts
+++ b/app/api/admin/export/assignments/pdf/route.ts
@@ -36,8 +36,9 @@ const HEADER_FONT_SIZE = 10;
 const TITLE_FONT_SIZE = 18;
 const LINE_HEIGHT = 13;
 const TABLE_HEADER_HEIGHT = 22;
-const TABLE_ROW_HEIGHT = 28;
-const COL_WIDTHS = [250, 70, 207];
+const TABLE_ROW_HEIGHT = 26;
+const SECTION_TITLE_HEIGHT = 20;
+const COL_WIDTHS = [80, 447];
 
 let fontEntryCache: Promise<FontEntry> | null = null;
 
@@ -240,29 +241,74 @@ function sortRows(rows: AssignmentExportRow[]): AssignmentExportRow[] {
   });
 }
 
+function groupRowsByTeam(
+  rows: AssignmentExportRow[],
+): Array<{ team: string; rows: AssignmentExportRow[] }> {
+  const groups = new Map<string, AssignmentExportRow[]>();
+
+  for (const row of rows) {
+    const team = row.team || '班未設定';
+    groups.set(team, [...(groups.get(team) || []), row]);
+  }
+
+  return Array.from(groups.entries()).map(([team, groupRows]) => ({
+    team,
+    rows: groupRows,
+  }));
+}
+
 async function buildPdf(input: { year: string; rows: AssignmentExportRow[] }) {
   const pdfDoc = await PDFDocument.create();
   pdfDoc.registerFontkit(fontkit);
   const fontEntry = await loadFontEntry();
   const font = await pdfDoc.embedFont(fontEntry.bytes, { subset: false });
-  const rows = sortRows(input.rows);
+  const groups = groupRowsByTeam(sortRows(input.rows));
   const header = `工大祭実行委員会-学外配布${input.year}`;
-  const firstPageIntroHeight = 68;
+  const pageChunks: Array<
+    Array<
+      { type: 'section'; team: string; count: number } | { type: 'row'; row: AssignmentExportRow }
+    >
+  > = [];
+  let current: Array<
+    { type: 'section'; team: string; count: number } | { type: 'row'; row: AssignmentExportRow }
+  > = [];
+  let usedHeight = 86;
   const usableHeight = CONTENT_TOP - CONTENT_BOTTOM;
-  const pageChunks: AssignmentExportRow[][] = [];
-  let current: AssignmentExportRow[] = [];
-  let usedHeight = firstPageIntroHeight + TABLE_HEADER_HEIGHT;
 
-  for (const row of rows) {
-    if (current.length > 0 && usedHeight + TABLE_ROW_HEIGHT > usableHeight) {
-      pageChunks.push(current);
-      current = [];
-      usedHeight = TABLE_HEADER_HEIGHT;
+  const pushPage = () => {
+    pageChunks.push(current);
+    current = [];
+    usedHeight = 0;
+  };
+
+  for (const group of groups) {
+    const sectionHeight = SECTION_TITLE_HEIGHT + TABLE_HEADER_HEIGHT;
+    if (current.length > 0 && usedHeight + sectionHeight + TABLE_ROW_HEIGHT > usableHeight) {
+      pushPage();
     }
-    current.push(row);
-    usedHeight += TABLE_ROW_HEIGHT;
+
+    current.push({ type: 'section', team: group.team, count: group.rows.length });
+    usedHeight += sectionHeight;
+
+    for (const row of group.rows) {
+      if (usedHeight + TABLE_ROW_HEIGHT > usableHeight) {
+        pushPage();
+        current.push({
+          type: 'section',
+          team: `${group.team}（続き）`,
+          count: group.rows.length,
+        });
+        usedHeight += sectionHeight;
+      }
+
+      current.push({ type: 'row', row });
+      usedHeight += TABLE_ROW_HEIGHT;
+    }
   }
 
+  if (current.length === 0) {
+    current.push({ type: 'section', team: '割り当てなし', count: 0 });
+  }
   pageChunks.push(current);
 
   for (const [pageIndex, items] of pageChunks.entries()) {
@@ -289,7 +335,7 @@ async function buildPdf(input: { year: string; rows: AssignmentExportRow[] }) {
       drawText({
         page,
         font,
-        text: `年度: ${input.year}　割り当て数: ${rows.length}名　出力日時: ${formatDate(new Date())}`,
+        text: `年度: ${input.year}　割り当て数: ${input.rows.length}名　出力日時: ${formatDate(new Date())}`,
         x: MARGIN_X,
         y,
         size: HEADER_FONT_SIZE,
@@ -304,27 +350,40 @@ async function buildPdf(input: { year: string; rows: AssignmentExportRow[] }) {
       y -= 40;
     }
 
-    let x = MARGIN_X;
-    for (const [index, title] of ['チーム', '学年', '氏名'].entries()) {
-      drawWrappedCell({
-        page,
-        font,
-        text: title,
-        x,
-        y: y - TABLE_HEADER_HEIGHT,
-        width: COL_WIDTHS[index],
-        height: TABLE_HEADER_HEIGHT,
-        size: FONT_SIZE,
-        maxLines: 1,
-        fill: true,
-      });
-      x += COL_WIDTHS[index];
-    }
-    y -= TABLE_HEADER_HEIGHT;
-
     for (const row of items) {
-      const values = [row.team || '-', row.grade > 0 ? `${row.grade}年` : '-', row.name || '-'];
-      x = MARGIN_X;
+      if (row.type === 'section') {
+        drawText({
+          page,
+          font,
+          text: `${row.team} ${row.count}名`,
+          x: MARGIN_X,
+          y: y - 14,
+          size: 12,
+        });
+        y -= SECTION_TITLE_HEIGHT;
+
+        let headerX = MARGIN_X;
+        for (const [index, title] of ['学年', '氏名'].entries()) {
+          drawWrappedCell({
+            page,
+            font,
+            text: title,
+            x: headerX,
+            y: y - TABLE_HEADER_HEIGHT,
+            width: COL_WIDTHS[index],
+            height: TABLE_HEADER_HEIGHT,
+            size: FONT_SIZE,
+            maxLines: 1,
+            fill: true,
+          });
+          headerX += COL_WIDTHS[index];
+        }
+        y -= TABLE_HEADER_HEIGHT;
+        continue;
+      }
+
+      const values = [row.row.grade > 0 ? `${row.row.grade}年` : '-', row.row.name || '-'];
+      let x = MARGIN_X;
       for (const [index, value] of values.entries()) {
         drawWrappedCell({
           page,
@@ -334,7 +393,7 @@ async function buildPdf(input: { year: string; rows: AssignmentExportRow[] }) {
           y: y - TABLE_ROW_HEIGHT,
           width: COL_WIDTHS[index],
           height: TABLE_ROW_HEIGHT,
-          maxLines: index === 0 ? 2 : 1,
+          maxLines: index === 1 ? 2 : 1,
         });
         x += COL_WIDTHS[index];
       }

--- a/app/api/admin/export/responses/pdf/route.ts
+++ b/app/api/admin/export/responses/pdf/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { readFile } from 'fs/promises';
-import path from 'path';
-import { PDFDocument, PDFPage, PDFFont, rgb } from 'pdf-lib';
-import fontkit from '@pdf-lib/fontkit';
 import { adminAuth } from '@/lib/firebase-admin';
+import { buildSectionedTableReportPdf } from '@/lib/server/pdf/sectioned-table-report';
 import { hasAdminPrivileges } from '@/lib/utils/admin/auth';
 import {
   formatResponseExportAvailability,
@@ -20,27 +17,7 @@ type PdfRequestBody = {
   rows?: unknown;
 };
 
-type FontEntry = {
-  bytes: Uint8Array;
-};
-
-const PAGE_WIDTH = 595.28;
-const PAGE_HEIGHT = 841.89;
-const MARGIN_X = 34;
-const HEADER_Y = PAGE_HEIGHT - 28;
-const FOOTER_Y = 24;
-const CONTENT_TOP = PAGE_HEIGHT - 55;
-const CONTENT_BOTTOM = 48;
-const FONT_SIZE = 9;
-const HEADER_FONT_SIZE = 10;
-const TITLE_FONT_SIZE = 18;
-const LINE_HEIGHT = 12;
-const TABLE_HEADER_HEIGHT = 20;
-const TABLE_ROW_HEIGHT = 43;
-const SECTION_TITLE_HEIGHT = 18;
 const COL_WIDTHS = [96, 78, 236, 117];
-
-let fontEntryCache: Promise<FontEntry> | null = null;
 
 function normalizeString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -67,336 +44,45 @@ function normalizeRows(value: unknown): ResponseExportRow[] {
   });
 }
 
-async function loadFontEntry(): Promise<FontEntry> {
-  if (!fontEntryCache) {
-    fontEntryCache = (async () => {
-      try {
-        const fontPath = path.join(
-          process.cwd(),
-          'node_modules',
-          '@expo-google-fonts',
-          'noto-sans-jp',
-          '400Regular',
-          'NotoSansJP_400Regular.ttf',
-        );
-        return {
-          bytes: await readFile(fontPath),
-        };
-      } catch (error) {
-        fontEntryCache = null;
-        throw error;
-      }
-    })();
-  }
-
-  return fontEntryCache;
-}
-
-function splitTextToLines(input: {
-  font: PDFFont;
-  text: string;
-  maxWidth: number;
-  size: number;
-  maxLines: number;
-}): string[] {
-  const lines: string[] = [];
-  let current = '';
-  let currentWidth = 0;
-  const chars = Array.from(input.text || '-');
-
-  for (const char of chars) {
-    const width = input.font.widthOfTextAtSize(char, input.size);
-    if (current && currentWidth + width > input.maxWidth) {
-      lines.push(current);
-      current = char;
-      currentWidth = width;
-      if (lines.length >= input.maxLines) break;
-    } else {
-      current += char;
-      currentWidth += width;
-    }
-  }
-
-  if (lines.length < input.maxLines && current) {
-    lines.push(current);
-  }
-
-  if (lines.length > 0 && chars.join('').length > lines.join('').length) {
-    lines[lines.length - 1] = `${lines[lines.length - 1].slice(0, -1)}…`;
-  }
-
-  return lines.length > 0 ? lines : ['-'];
-}
-
-function drawTextRun(input: {
-  page: PDFPage;
-  font: PDFFont;
-  text: string;
-  x: number;
-  y: number;
-  size: number;
-  color?: ReturnType<typeof rgb>;
-}) {
-  input.page.drawText(input.text, {
-    x: input.x,
-    y: input.y,
-    size: input.size,
-    font: input.font,
-    color: input.color || rgb(0.07, 0.09, 0.15),
-  });
-}
-
-function measureTextWidth(input: { font: PDFFont; text: string; size: number }): number {
-  return input.font.widthOfTextAtSize(input.text, input.size);
-}
-
-function drawRect(
-  page: PDFPage,
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  fill: boolean,
-) {
-  page.drawRectangle({
-    x,
-    y,
-    width,
-    height,
-    borderWidth: 0.5,
-    borderColor: rgb(0.82, 0.84, 0.88),
-    color: fill ? rgb(0.95, 0.96, 0.98) : undefined,
-  });
-}
-
-function drawWrappedCell(input: {
-  page: PDFPage;
-  font: PDFFont;
-  text: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  size?: number;
-  maxLines?: number;
-  fill?: boolean;
-}) {
-  drawRect(input.page, input.x, input.y, input.width, input.height, Boolean(input.fill));
-  const size = input.size || FONT_SIZE;
-  const lines = splitTextToLines({
-    font: input.font,
-    text: input.text,
-    maxWidth: input.width - 8,
-    size,
-    maxLines: input.maxLines || 3,
-  });
-  const totalTextHeight = lines.length * LINE_HEIGHT;
-  let textY = input.y + (input.height - totalTextHeight) / 2 + (LINE_HEIGHT - size) / 2;
-  textY += (lines.length - 1) * LINE_HEIGHT;
-
-  for (const line of lines) {
-    drawTextRun({
-      page: input.page,
-      font: input.font,
-      text: line,
-      x: input.x + 4,
-      y: textY,
-      size,
-    });
-    textY -= LINE_HEIGHT;
-  }
-}
-
-function drawHeaderFooter(input: {
-  page: PDFPage;
-  font: PDFFont;
-  header: string;
-  pageNumber: number;
-  pageCount: number;
-}) {
-  drawTextRun({
-    page: input.page,
-    font: input.font,
-    text: input.header,
-    x: MARGIN_X,
-    y: HEADER_Y,
-    size: HEADER_FONT_SIZE,
-    color: rgb(0.22, 0.26, 0.32),
-  });
-  drawTextRun({
-    page: input.page,
-    font: input.font,
-    text: 'PR系',
-    x: MARGIN_X,
-    y: FOOTER_Y,
-    size: HEADER_FONT_SIZE,
-    color: rgb(0.22, 0.26, 0.32),
-  });
-  const pageNumberText = `[${input.pageNumber}/${input.pageCount}]`;
-  const pageNumberWidth = measureTextWidth({
-    font: input.font,
-    text: pageNumberText,
-    size: HEADER_FONT_SIZE,
-  });
-  drawTextRun({
-    page: input.page,
-    font: input.font,
-    text: pageNumberText,
-    x: PAGE_WIDTH - MARGIN_X - pageNumberWidth,
-    y: FOOTER_Y,
-    size: HEADER_FONT_SIZE,
-    color: rgb(0.22, 0.26, 0.32),
-  });
-}
-
 async function buildPdf(input: { year: string; formTitle: string; rows: ResponseExportRow[] }) {
-  const pdfDoc = await PDFDocument.create();
-  pdfDoc.registerFontkit(fontkit);
-  const fontEntry = await loadFontEntry();
-  const font = await pdfDoc.embedFont(fontEntry.bytes, { subset: false });
   const grouped = groupResponseExportRowsByGrade(input.rows);
-  const header = `工大祭実行委員会-学外配布${input.year}`;
-  const pageChunks: Array<
-    Array<
-      { type: 'section'; label: string; count: number } | { type: 'row'; row: ResponseExportRow }
-    >
-  > = [];
-  let current: Array<
-    { type: 'section'; label: string; count: number } | { type: 'row'; row: ResponseExportRow }
-  > = [];
-  let usedHeight = 86;
-
-  const pushPage = () => {
-    pageChunks.push(current);
-    current = [];
-    usedHeight = 0;
-  };
-
-  for (const group of grouped) {
-    const sectionHeight = SECTION_TITLE_HEIGHT + TABLE_HEADER_HEIGHT;
-    if (
-      current.length > 0 &&
-      usedHeight + sectionHeight + TABLE_ROW_HEIGHT > CONTENT_TOP - CONTENT_BOTTOM
-    ) {
-      pushPage();
-    }
-    current.push({ type: 'section', label: group.label, count: group.rows.length });
-    usedHeight += sectionHeight;
-    for (const row of group.rows) {
-      if (usedHeight + TABLE_ROW_HEIGHT > CONTENT_TOP - CONTENT_BOTTOM) {
-        pushPage();
-        current.push({
-          type: 'section',
-          label: `${group.label}（続き）`,
-          count: group.rows.length,
-        });
-        usedHeight += sectionHeight;
-      }
-      current.push({ type: 'row', row });
-      usedHeight += TABLE_ROW_HEIGHT;
-    }
-  }
-
-  if (current.length === 0) {
-    current.push({ type: 'section', label: '回答なし', count: 0 });
-  }
-  pageChunks.push(current);
-
-  for (const [pageIndex, items] of pageChunks.entries()) {
-    const page = pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
-    drawHeaderFooter({
-      page,
-      font,
-      header,
-      pageNumber: pageIndex + 1,
-      pageCount: pageChunks.length,
-    });
-
-    let y = CONTENT_TOP;
-    if (pageIndex === 0) {
-      drawTextRun({
-        page,
-        font,
-        text: '回答者一覧',
-        x: MARGIN_X,
-        y,
-        size: TITLE_FONT_SIZE,
-      });
-      y -= 20;
-      drawTextRun({
-        page,
-        font,
-        text: `フォーム: ${input.formTitle}　回答数: ${input.rows.length}名　出力日時: ${formatDate(new Date())}`,
-        x: MARGIN_X,
-        y,
-        size: HEADER_FONT_SIZE,
-        color: rgb(0.29, 0.33, 0.39),
-      });
-      page.drawLine({
-        start: { x: MARGIN_X, y: y - 8 },
-        end: { x: PAGE_WIDTH - MARGIN_X, y: y - 8 },
-        thickness: 0.5,
-        color: rgb(0.82, 0.84, 0.88),
-      });
-      y -= 28;
-    }
-
-    for (const item of items) {
-      if (item.type === 'section') {
-        drawTextRun({
-          page,
-          font,
-          text: `${item.label} ${item.count}名`,
-          x: MARGIN_X,
-          y: y - 13,
-          size: 12,
-        });
-        y -= SECTION_TITLE_HEIGHT;
-        let x = MARGIN_X;
-        for (const [index, title] of ['名前', 'セクション', '参加可能日時', '回答日時'].entries()) {
-          drawWrappedCell({
-            page,
-            font,
-            text: title,
-            x,
-            y: y - TABLE_HEADER_HEIGHT,
-            width: COL_WIDTHS[index],
-            height: TABLE_HEADER_HEIGHT,
-            size: FONT_SIZE,
-            maxLines: 1,
-            fill: true,
-          });
-          x += COL_WIDTHS[index];
-        }
-        y -= TABLE_HEADER_HEIGHT;
-        continue;
-      }
-
-      const values = [
-        item.row.name || '名前未入力',
-        item.row.section,
-        formatResponseExportAvailability(item.row),
-        formatDate(item.row.submittedAt),
-      ];
-      let x = MARGIN_X;
-      for (const [index, value] of values.entries()) {
-        drawWrappedCell({
-          page,
-          font,
-          text: value,
-          x,
-          y: y - TABLE_ROW_HEIGHT,
-          width: COL_WIDTHS[index],
-          height: TABLE_ROW_HEIGHT,
-          maxLines: index === 2 ? 3 : 2,
-        });
-        x += COL_WIDTHS[index];
-      }
-      y -= TABLE_ROW_HEIGHT;
-    }
-  }
-
-  return pdfDoc.save();
+  return buildSectionedTableReportPdf({
+    title: '回答者一覧',
+    metaText: `フォーム: ${input.formTitle}　回答数: ${input.rows.length}名　出力日時: ${formatDate(new Date())}`,
+    header: `工大祭実行委員会-学外配布${input.year}`,
+    sections: grouped.map((group) => ({
+      label: group.label,
+      count: group.rows.length,
+      rows: group.rows,
+    })),
+    emptySectionLabel: '回答なし',
+    columns: [
+      {
+        title: '名前',
+        width: COL_WIDTHS[0],
+        getText: (row) => row.name || '名前未入力',
+        maxLines: 2,
+      },
+      {
+        title: 'セクション',
+        width: COL_WIDTHS[1],
+        getText: (row) => row.section,
+        maxLines: 2,
+      },
+      {
+        title: '参加可能日時',
+        width: COL_WIDTHS[2],
+        getText: (row) => formatResponseExportAvailability(row),
+        maxLines: 3,
+      },
+      {
+        title: '回答日時',
+        width: COL_WIDTHS[3],
+        getText: (row) => formatDate(row.submittedAt),
+        maxLines: 2,
+      },
+    ],
+  });
 }
 
 export async function POST(request: NextRequest) {

--- a/app/api/admin/teams/[teamId]/members/route.ts
+++ b/app/api/admin/teams/[teamId]/members/route.ts
@@ -7,6 +7,7 @@ import { normalizeGrade } from '@/lib/utils/grade/grade';
 type MemberItem = {
   responseId: string;
   name: string;
+  nameKana: string;
   grade: number;
   section: string;
   timeSlot: string;
@@ -101,6 +102,7 @@ export async function GET(
       members.push({
         responseId: a.responseId,
         name: pd.name || '-',
+        nameKana: pd.nameKana || '',
         grade: normalizeGrade(pd.grade),
         section: pd.section || '-',
         timeSlot: String(a.timeSlot || ''),

--- a/lib/server/pdf/sectioned-table-report.ts
+++ b/lib/server/pdf/sectioned-table-report.ts
@@ -1,0 +1,427 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import fontkit from '@pdf-lib/fontkit';
+import { PDFDocument, PDFPage, PDFFont, rgb } from 'pdf-lib';
+
+type FontEntry = {
+  bytes: Uint8Array;
+};
+
+export type PdfTableColumn<Row> = {
+  title: string;
+  width: number;
+  getText: (row: Row) => string;
+  maxLines?: number;
+};
+
+export type PdfTableSection<Row> = {
+  label: string;
+  count: number;
+  rows: Row[];
+};
+
+export type SectionedTableReportOptions<Row> = {
+  title: string;
+  metaText: string;
+  header: string;
+  sections: PdfTableSection<Row>[];
+  emptySectionLabel: string;
+  columns: PdfTableColumn<Row>[];
+  headerFontSize?: number;
+  titleFontSize?: number;
+};
+
+const PAGE_WIDTH = 595.28;
+const PAGE_HEIGHT = 841.89;
+const MARGIN_X = 34;
+const HEADER_Y = PAGE_HEIGHT - 28;
+const FOOTER_Y = 24;
+const CONTENT_TOP = PAGE_HEIGHT - 55;
+const CONTENT_BOTTOM = 48;
+const FONT_SIZE = 9;
+const DEFAULT_HEADER_FONT_SIZE = 10;
+const DEFAULT_TITLE_FONT_SIZE = 18;
+const LINE_HEIGHT = 12;
+const TABLE_HEADER_HEIGHT = 20;
+const TABLE_ROW_MIN_HEIGHT = 20;
+const SECTION_TITLE_HEIGHT = 18;
+const FIRST_PAGE_INTRO_HEIGHT = 86;
+const TITLE_GAP = 20;
+const DIVIDER_OFFSET = 8;
+const INTRO_BOTTOM_GAP = 28;
+const CELL_HORIZONTAL_PADDING = 4;
+const CELL_VERTICAL_PADDING = 8;
+
+let fontEntryCache: Promise<FontEntry> | null = null;
+
+async function loadFontEntry(): Promise<FontEntry> {
+  if (!fontEntryCache) {
+    fontEntryCache = (async () => {
+      try {
+        const fontPath = path.join(
+          process.cwd(),
+          'node_modules',
+          '@expo-google-fonts',
+          'noto-sans-jp',
+          '400Regular',
+          'NotoSansJP_400Regular.ttf',
+        );
+        return {
+          bytes: await readFile(fontPath),
+        };
+      } catch (error) {
+        fontEntryCache = null;
+        throw error;
+      }
+    })();
+  }
+
+  return fontEntryCache;
+}
+
+function splitTextToLines(input: {
+  font: PDFFont;
+  text: string;
+  maxWidth: number;
+  size: number;
+  maxLines: number;
+}): string[] {
+  const lines: string[] = [];
+  let current = '';
+  let currentWidth = 0;
+  const chars = Array.from(input.text || '-');
+
+  for (const char of chars) {
+    const width = input.font.widthOfTextAtSize(char, input.size);
+    if (current && currentWidth + width > input.maxWidth) {
+      lines.push(current);
+      current = char;
+      currentWidth = width;
+      if (lines.length >= input.maxLines) break;
+    } else {
+      current += char;
+      currentWidth += width;
+    }
+  }
+
+  if (lines.length < input.maxLines && current) {
+    lines.push(current);
+  }
+
+  if (lines.length > 0 && chars.join('').length > lines.join('').length) {
+    lines[lines.length - 1] = `${lines[lines.length - 1].slice(0, -1)}…`;
+  }
+
+  return lines.length > 0 ? lines : ['-'];
+}
+
+function drawText(input: {
+  page: PDFPage;
+  font: PDFFont;
+  text: string;
+  x: number;
+  y: number;
+  size: number;
+  color?: ReturnType<typeof rgb>;
+}) {
+  input.page.drawText(input.text, {
+    x: input.x,
+    y: input.y,
+    size: input.size,
+    font: input.font,
+    color: input.color || rgb(0.07, 0.09, 0.15),
+  });
+}
+
+function drawRect(input: {
+  page: PDFPage;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  fill: boolean;
+}) {
+  input.page.drawRectangle({
+    x: input.x,
+    y: input.y,
+    width: input.width,
+    height: input.height,
+    borderWidth: 0.5,
+    borderColor: rgb(0.82, 0.84, 0.88),
+    color: input.fill ? rgb(0.95, 0.96, 0.98) : undefined,
+  });
+}
+
+function drawWrappedCell(input: {
+  page: PDFPage;
+  font: PDFFont;
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  fontSize: number;
+  lineHeight: number;
+  cellHorizontalPadding: number;
+  maxLines: number;
+  fill?: boolean;
+}) {
+  drawRect({
+    page: input.page,
+    x: input.x,
+    y: input.y,
+    width: input.width,
+    height: input.height,
+    fill: Boolean(input.fill),
+  });
+  const lines = splitTextToLines({
+    font: input.font,
+    text: input.text,
+    maxWidth: input.width - input.cellHorizontalPadding * 2,
+    size: input.fontSize,
+    maxLines: input.maxLines,
+  });
+  const totalTextHeight = lines.length * input.lineHeight;
+  let textY =
+    input.y + (input.height - totalTextHeight) / 2 + (input.lineHeight - input.fontSize) / 2;
+  textY += (lines.length - 1) * input.lineHeight;
+
+  for (const line of lines) {
+    drawText({
+      page: input.page,
+      font: input.font,
+      text: line,
+      x: input.x + input.cellHorizontalPadding,
+      y: textY,
+      size: input.fontSize,
+    });
+    textY -= input.lineHeight;
+  }
+}
+
+function drawHeaderFooter(input: {
+  page: PDFPage;
+  font: PDFFont;
+  header: string;
+  pageNumber: number;
+  pageCount: number;
+  headerFontSize: number;
+}) {
+  drawText({
+    page: input.page,
+    font: input.font,
+    text: input.header,
+    x: MARGIN_X,
+    y: HEADER_Y,
+    size: input.headerFontSize,
+    color: rgb(0.22, 0.26, 0.32),
+  });
+  drawText({
+    page: input.page,
+    font: input.font,
+    text: 'PR系',
+    x: MARGIN_X,
+    y: FOOTER_Y,
+    size: input.headerFontSize,
+    color: rgb(0.22, 0.26, 0.32),
+  });
+  const pageNumberText = `[${input.pageNumber}/${input.pageCount}]`;
+  drawText({
+    page: input.page,
+    font: input.font,
+    text: pageNumberText,
+    x: PAGE_WIDTH - MARGIN_X - input.font.widthOfTextAtSize(pageNumberText, input.headerFontSize),
+    y: FOOTER_Y,
+    size: input.headerFontSize,
+    color: rgb(0.22, 0.26, 0.32),
+  });
+}
+
+function calculateRowHeight<Row>(input: {
+  font: PDFFont;
+  columns: PdfTableColumn<Row>[];
+  row: Row;
+}): number {
+  const maxLineCount = Math.max(
+    1,
+    ...input.columns.map((column) => {
+      const lines = splitTextToLines({
+        font: input.font,
+        text: column.getText(input.row),
+        maxWidth: column.width - CELL_HORIZONTAL_PADDING * 2,
+        size: FONT_SIZE,
+        maxLines: column.maxLines || 2,
+      });
+      return lines.length;
+    }),
+  );
+
+  return Math.max(TABLE_ROW_MIN_HEIGHT, maxLineCount * LINE_HEIGHT + CELL_VERTICAL_PADDING);
+}
+
+export async function buildSectionedTableReportPdf<Row>(
+  options: SectionedTableReportOptions<Row>,
+): Promise<Uint8Array> {
+  const headerFontSize = options.headerFontSize || DEFAULT_HEADER_FONT_SIZE;
+  const titleFontSize = options.titleFontSize || DEFAULT_TITLE_FONT_SIZE;
+  const usableHeight = CONTENT_TOP - CONTENT_BOTTOM;
+  const sectionHeight = SECTION_TITLE_HEIGHT + TABLE_HEADER_HEIGHT;
+  const pdfDoc = await PDFDocument.create();
+  pdfDoc.registerFontkit(fontkit);
+  const fontEntry = await loadFontEntry();
+  const font = await pdfDoc.embedFont(fontEntry.bytes, { subset: false });
+  const pageChunks: Array<
+    Array<
+      { type: 'section'; label: string; count: number } | { type: 'row'; row: Row; height: number }
+    >
+  > = [];
+  let current: Array<
+    { type: 'section'; label: string; count: number } | { type: 'row'; row: Row; height: number }
+  > = [];
+  let usedHeight = FIRST_PAGE_INTRO_HEIGHT;
+
+  const pushPage = () => {
+    pageChunks.push(current);
+    current = [];
+    usedHeight = 0;
+  };
+
+  for (const section of options.sections) {
+    const firstRowHeight = section.rows[0]
+      ? calculateRowHeight({
+          font,
+          columns: options.columns,
+          row: section.rows[0],
+        })
+      : 0;
+    if (current.length > 0 && usedHeight + sectionHeight + firstRowHeight > usableHeight) {
+      pushPage();
+    }
+
+    current.push({ type: 'section', label: section.label, count: section.count });
+    usedHeight += sectionHeight;
+
+    for (const row of section.rows) {
+      const rowHeight = calculateRowHeight({
+        font,
+        columns: options.columns,
+        row,
+      });
+
+      if (usedHeight + rowHeight > usableHeight) {
+        pushPage();
+        current.push({
+          type: 'section',
+          label: `${section.label}（続き）`,
+          count: section.count,
+        });
+        usedHeight += sectionHeight;
+      }
+
+      current.push({ type: 'row', row, height: rowHeight });
+      usedHeight += rowHeight;
+    }
+  }
+
+  if (current.length === 0) {
+    current.push({ type: 'section', label: options.emptySectionLabel, count: 0 });
+  }
+  pageChunks.push(current);
+
+  for (const [pageIndex, items] of pageChunks.entries()) {
+    const page = pdfDoc.addPage([PAGE_WIDTH, PAGE_HEIGHT]);
+    drawHeaderFooter({
+      page,
+      font,
+      header: options.header,
+      pageNumber: pageIndex + 1,
+      pageCount: pageChunks.length,
+      headerFontSize,
+    });
+
+    let y = CONTENT_TOP;
+    if (pageIndex === 0) {
+      drawText({
+        page,
+        font,
+        text: options.title,
+        x: MARGIN_X,
+        y,
+        size: titleFontSize,
+      });
+      y -= TITLE_GAP;
+      drawText({
+        page,
+        font,
+        text: options.metaText,
+        x: MARGIN_X,
+        y,
+        size: headerFontSize,
+        color: rgb(0.29, 0.33, 0.39),
+      });
+      page.drawLine({
+        start: { x: MARGIN_X, y: y - DIVIDER_OFFSET },
+        end: { x: PAGE_WIDTH - MARGIN_X, y: y - DIVIDER_OFFSET },
+        thickness: 0.5,
+        color: rgb(0.82, 0.84, 0.88),
+      });
+      y -= INTRO_BOTTOM_GAP;
+    }
+
+    for (const item of items) {
+      if (item.type === 'section') {
+        drawText({
+          page,
+          font,
+          text: `${item.label} ${item.count}名`,
+          x: MARGIN_X,
+          y: y - Math.max(13, SECTION_TITLE_HEIGHT - 6),
+          size: 12,
+        });
+        y -= SECTION_TITLE_HEIGHT;
+
+        let x = MARGIN_X;
+        for (const column of options.columns) {
+          drawWrappedCell({
+            page,
+            font,
+            text: column.title,
+            x,
+            y: y - TABLE_HEADER_HEIGHT,
+            width: column.width,
+            height: TABLE_HEADER_HEIGHT,
+            fontSize: FONT_SIZE,
+            lineHeight: LINE_HEIGHT,
+            cellHorizontalPadding: CELL_HORIZONTAL_PADDING,
+            maxLines: 1,
+            fill: true,
+          });
+          x += column.width;
+        }
+        y -= TABLE_HEADER_HEIGHT;
+        continue;
+      }
+
+      let x = MARGIN_X;
+      for (const column of options.columns) {
+        drawWrappedCell({
+          page,
+          font,
+          text: column.getText(item.row),
+          x,
+          y: y - item.height,
+          width: column.width,
+          height: item.height,
+          fontSize: FONT_SIZE,
+          lineHeight: LINE_HEIGHT,
+          cellHorizontalPadding: CELL_HORIZONTAL_PADDING,
+          maxLines: column.maxLines || 2,
+        });
+        x += column.width;
+      }
+      y -= item.height;
+    }
+  }
+
+  return pdfDoc.save();
+}

--- a/lib/utils/sort.ts
+++ b/lib/utils/sort.ts
@@ -1,0 +1,33 @@
+import { normalizeGrade } from './grade/grade';
+import { generateKana } from '../kanaUtils';
+
+const japaneseCollator = new Intl.Collator('ja');
+
+export function compareJapaneseText(a: unknown, b: unknown): number {
+  return japaneseCollator.compare(String(a || ''), String(b || ''));
+}
+
+export function compareGradeThenKanaThenName(
+  a: { grade?: unknown; nameKana?: unknown; name?: unknown; responseId?: unknown },
+  b: { grade?: unknown; nameKana?: unknown; name?: unknown; responseId?: unknown },
+): number {
+  const aGrade = normalizeGrade(a.grade);
+  const bGrade = normalizeGrade(b.grade);
+  if (aGrade !== bGrade) return aGrade - bGrade;
+
+  const aSortName = generateKana(String(a.nameKana || a.name || ''));
+  const bSortName = generateKana(String(b.nameKana || b.name || ''));
+  const kanaCompare = compareJapaneseText(aSortName, bSortName);
+  if (kanaCompare !== 0) return kanaCompare;
+
+  const nameCompare = compareJapaneseText(a.name, b.name);
+  if (nameCompare !== 0) return nameCompare;
+
+  return compareJapaneseText(a.responseId, b.responseId);
+}
+
+export function sortByGradeThenKanaThenName<
+  T extends { grade?: unknown; nameKana?: unknown; name?: unknown; responseId?: unknown },
+>(items: T[]): T[] {
+  return [...items].sort(compareGradeThenKanaThenName);
+}

--- a/lib/utils/sort.ts
+++ b/lib/utils/sort.ts
@@ -4,7 +4,7 @@ import { generateKana } from '../kanaUtils';
 const japaneseCollator = new Intl.Collator('ja');
 
 export function compareJapaneseText(a: unknown, b: unknown): number {
-  return japaneseCollator.compare(String(a || ''), String(b || ''));
+  return japaneseCollator.compare(String(a ?? ''), String(b ?? ''));
 }
 
 export function compareGradeThenKanaThenName(

--- a/tests/sort.test.ts
+++ b/tests/sort.test.ts
@@ -6,6 +6,7 @@ describe('sort utils', () => {
   test('compareJapaneseText compares values with Japanese collation', () => {
     assert.equal(compareJapaneseText('あ', 'い') < 0, true);
     assert.equal(compareJapaneseText(null, '') === 0, true);
+    assert.equal(compareJapaneseText(0, '0') === 0, true);
   });
 
   test('sortByGradeThenKanaThenName sorts by grade, kana, name, and response id', () => {

--- a/tests/sort.test.ts
+++ b/tests/sort.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { compareJapaneseText, sortByGradeThenKanaThenName } from '../lib/utils/sort';
+
+describe('sort utils', () => {
+  test('compareJapaneseText compares values with Japanese collation', () => {
+    assert.equal(compareJapaneseText('あ', 'い') < 0, true);
+    assert.equal(compareJapaneseText(null, '') === 0, true);
+  });
+
+  test('sortByGradeThenKanaThenName sorts by grade, kana, name, and response id', () => {
+    const rows = sortByGradeThenKanaThenName([
+      { responseId: 'r5', grade: 1, nameKana: 'いとう', name: '伊東' },
+      { responseId: 'r3', grade: 2, nameKana: 'さとう', name: '佐藤' },
+      { responseId: 'r2', grade: 1, nameKana: 'いとう', name: '伊藤' },
+      { responseId: 'r4', grade: 1, nameKana: 'いとう', name: '伊藤' },
+      { responseId: 'r1', grade: 1, nameKana: 'あべ', name: '阿部' },
+    ]);
+
+    assert.deepEqual(
+      rows.map((row) => row.responseId),
+      ['r1', 'r5', 'r2', 'r4', 'r3'],
+    );
+  });
+});


### PR DESCRIPTION
## 📊 Pull Request 実装状況レポート
## 🟢 **実装完了**

### Issues #141 : チームの割り当てのソート

- [x] チーム割り当ての参加者名をソートできるようにした

### Issues #142 : チームの割り当てメンバーの検索

- [x] チームの割り当てメンバーの検索をできるようにした

### Issues 143 : チームの割り当てメンバーのPDFエクスポート

- [x] チームの割り当てメンバーのPDFエクスポートのUIを修正した

---

## 🏗️ **追加実装内容**

### 各種機能のコンポーネント化
 
---

## 🧪 **動作確認済み機能**

- [x] 各種機能が動作することを確認した

## 関連Issues
fix #141 
fix #142 
fix #143 